### PR TITLE
Overhaul PPL backend: bug fixes, style fixes, removal of per-rule custom time attribute support and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ This backend is currently maintained by:
 
 * [Hendrik Bäcker](https://github.com/andurin/)
 
+## PPL Backend
+
+The PPL backend only supports the default output format, emitting queries that can be used in OpenSearch Dashboards versions newer than 3.4 or through the [PPL search API](https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/index/).
+
+OpenSearch monitors using PPL are still a planned/WIP feature in OpenSearch 3.7. This backend will be updated to support them when this feature becomes stable.
+
 # Background
 
 ## Lucene Backend
@@ -322,62 +328,12 @@ You can configure PPL backend behavior with custom attributes in Sigma rules or 
 
 ## PPL Backend Custom Attributes
 
-The PPL backend supports the following custom attributes that can be specified in the `custom` section of a Sigma rule:
+The PPL backend supports the following custom attributes that can be specified in the `opensearch_ppl_backend` section of a Sigma rule:
 
 ```yaml
-custom:
-  opensearch_ppl_index: "custom-logs-*"        # Override default index pattern
-  opensearch_ppl_min_time: "-30d"              # Set query time window start
-  opensearch_ppl_max_time: "now"               # Set query time window end
+opensearch_ppl_backend:
+  index: "custom-logs-*"        # Override default index pattern
 ```
-
-### Example with Custom Attributes
-
-This example shows how custom attributes work with correlation rules, where individual detection rules can have their own time windows or inherit from the correlation rule:
-
-```yaml
-title: Detection Rule 1 - With Own Time Filter
-id: 10000400-0000-0000-0000-000000000004
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine|contains: 'malware'
-  condition: selection
-custom:
-  opensearch_ppl_min_time: "-7d"    # This rule uses 7 days
-  opensearch_ppl_max_time: "now"
----
-title: Detection Rule 2 - No Time Filter
-id: 10000401-0000-0000-0000-000000000004
-logsource:
-  product: windows
-  category: network_connection
-detection:
-  selection:
-    DestinationPort: 443
-  condition: selection
-# No custom attributes - will inherit from correlation
----
-title: Correlation - Mixed Time Filters
-id: 10000402-0000-0000-0000-000000000004
-correlation:
-  type: temporal
-  rules:
-    - 10000400-0000-0000-0000-000000000004
-    - 10000401-0000-0000-0000-000000000004
-  group-by:
-    - Computer
-  timespan: 5m
-custom:
-  opensearch_ppl_min_time: "-30d"   # Rule 2 inherits this (30 days)
-  opensearch_ppl_max_time: "now"
-```
-
-**Result**: 
-- Detection Rule 1 will search the last **7 days** (its own custom attribute)
-- Detection Rule 2 will search the last **30 days** (inherited from correlation rule)
 
 ### Backend Options
 

--- a/sigma/backends/opensearch/opensearch_ppl.py
+++ b/sigma/backends/opensearch/opensearch_ppl.py
@@ -9,754 +9,455 @@ Supports:
 - Correlation rules (event_count, value_count, temporal, temporal_ordered)
 - All standard Sigma modifiers and features
 """
-from typing import ClassVar, Optional, Pattern, Dict, Union, Any, List
+
+from typing import ClassVar, Optional, Pattern, Dict, Any, List
 import re
 from enum import Enum
 
-from sigma.conversion.base import TextQueryBackend
-from sigma.conversion.state import ConversionState
+from sigma.conversion.base import TextQueryBackend  # pyright: ignore[reportMissingTypeStubs]
+from sigma.conversion.deferred import (  # pyright: ignore[reportMissingTypeStubs]
+    DeferredQueryExpression,
+    DeferredTextQueryExpression,
+)
+from sigma.conversion.state import ConversionState  # pyright: ignore[reportMissingTypeStubs]
 from sigma.correlations import (
     SigmaCorrelationRule,
-    SigmaCorrelationTypeLiteral,
-    SigmaCorrelationType,
 )
-from sigma.exceptions import SigmaConversionError
-from sigma.processing.pipeline import ProcessingPipeline
-from sigma.rule import SigmaRule
-from sigma.types import SigmaCompareExpression
-from sigma.conditions import ConditionItem, ConditionAND, ConditionOR, ConditionNOT
+from sigma.exceptions import SigmaValueError
+from sigma.processing.pipeline import ProcessingPipeline  # pyright: ignore[reportMissingTypeStubs]
+from sigma.rule import SigmaRule  # pyright: ignore[reportMissingTypeStubs]
+from sigma.types import CompareOperators, SigmaCompareExpression
+from sigma.conditions import (
+    ConditionAND,
+    ConditionFieldEqualsValueExpression,
+    ConditionItem,
+    ConditionOR,
+    ConditionNOT,
+)
 
 
-# ============================================================================
-# Custom Attributes
-# ============================================================================
+class PPLDeferredRegexExpression(DeferredTextQueryExpression):
+    template: ClassVar[str] = 'regex {field}{op}"{value}"'
+    operators: ClassVar[Dict[bool, str]] = {
+        True: "!=",
+        False: "=",
+    }
+    # OpenSearch does not really have an equivalent to Splunk's `_raw`
+    # We chose message as it is closest in meaning, but it is not equivalent.
+    default_field: ClassVar[str | None] = "message"
+
 
 class OpenSearchPPLCustomAttributes(Enum):
     """
     Custom attributes that can be set in Sigma rules to configure OpenSearch PPL backend behavior.
-    
+
     These can be used in a Sigma rule YAML like:
-    
-    custom:
-      opensearch_ppl_index: "my-custom-index-*"
-      opensearch_ppl_time_field: "event_timestamp"
-      opensearch_ppl_min_time: "-7d"
-      opensearch_ppl_max_time: "now"
+
+    opensearch_ppl_backend:
+      index: "my-custom-index-*"
     """
-    INDEX = "opensearch_ppl_index"
-    TIME_FIELD = "opensearch_ppl_time_field"
-    MIN_TIME = "opensearch_ppl_min_time"
-    MAX_TIME = "opensearch_ppl_max_time"
+
+    INDEX = "index"
 
 
 class OpenSearchPPLBackend(TextQueryBackend):
     """
     OpenSearch PPL backend for both regular and correlation Sigma rules.
-    
+
     This backend leverages pySigma's built-in conversion infrastructure,
     requiring only configuration through class variables and minimal
     method overrides for PPL-specific behavior.
-    
+
     Features:
     - Converts regular Sigma detection rules to PPL queries
     - Supports correlation rules with multiple correlation types
     - Handles all standard Sigma modifiers (contains, startswith, etc.)
     - Supports CIDR notation, regex, field references, and more
     """
-    
+
     # Backend metadata
     name: ClassVar[str] = "OpenSearch PPL Backend"
     formats: ClassVar[Dict[str, str]] = {
         "default": "Plain PPL queries",
-        "kibana": "Kibana dashboard format (future)",
+        # "kibana": "Kibana dashboard format (future)",
     }
     requires_pipeline: ClassVar[bool] = False
-    
+
     # Operator precedence (NOT > AND > OR)
-    precedence: ClassVar[tuple] = (ConditionNOT, ConditionAND, ConditionOR)
-    group_expression: ClassVar[str] = "({expr})"
-    
-    # Boolean operators for PPL
+    precedence: ClassVar[
+        tuple[type[ConditionItem], type[ConditionItem], type[ConditionItem]]
+    ] = (ConditionNOT, ConditionAND, ConditionOR)
+    group_expression: ClassVar[str | None] = "({expr})"
+
+    # Generated query tokens
     token_separator: str = " "
     or_token: ClassVar[str] = "OR"
     and_token: ClassVar[str] = "AND"
     not_token: ClassVar[str] = "NOT"
     eq_token: ClassVar[str] = "="
-    
-    # Field quoting - PPL allows unquoted alphanumeric field names
-    field_quote: ClassVar[str] = "`"  # Backticks for fields with special chars
-    field_quote_pattern: ClassVar[Pattern] = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-    field_quote_pattern_negation: ClassVar[bool] = True  # Quote if pattern does NOT match
-    
-    # String quoting and escaping  
+
+    # Query structure
+    query_expression: ClassVar[str] = "{query}"
+
+    # String output
+    ## Fields
+    ### Quoting
+    # PPL allows unquoted alphanumeric field names
+    field_quote: ClassVar[str | None] = "`"  # Backticks for fields with special chars
+    field_quote_pattern: ClassVar[Pattern[str] | None] = re.compile(
+        r"^[a-zA-Z_][a-zA-Z0-9_]*$"
+    )
+    field_quote_pattern_negation: ClassVar[bool] = (
+        True  # Quote if pattern does NOT match
+    )
+
+    ## Values
+    ### String quoting
     str_quote: ClassVar[str] = '"'  # Double quotes for string values
-    escape_char: ClassVar[str] = '\\'
-    wildcard_multi: ClassVar[str] = "%"  # PPL uses % for multi-character wildcard
-    wildcard_single: ClassVar[str] = "_"  # PPL uses _ for single-character wildcard
-    # Note: PPL LIKE patterns don't support backslash escape sequences
-    # We need to remove backslashes from LIKE patterns in post-processing
-    add_escaped: ClassVar[str] = ""  # Empty to avoid escaping backslashes
-    filter_chars: ClassVar[str] = "\\"  # Remove backslashes from patterns
-    
+    ### String escaping and filtering
+    escape_char: ClassVar[str | None] = "\\"
+    wildcard_multi: ClassVar[str | None] = (
+        "%"  # PPL LIKE function uses % for multi-character wildcard
+    )
+    wildcard_single: ClassVar[str | None] = (
+        "_"  # PPL LIKE function uses _ for single-character wildcard
+    )
+    # Note: At the time of writing, there is an issue with backslashes used in
+    # PPL LIKE patterns. Queries are emmitted with the expected behaviour, even
+    # if it doesn't work for now.
+    # https://github.com/opensearch-project/sql/issues/5627
+    add_escaped: ClassVar[str] = "\\"  # escape backslashes
+
+    ### Booleans
+    bool_values: ClassVar[
+        dict[bool, str | None]
+    ] = {  # Values to which boolean values are mapped.
+        True: "true",
+        False: "false",
+    }
+
     # String matching operators with PPL's LIKE() function
-    # PPL uses: LIKE(field, "pattern") with % for wildcards  
-    # PPL uses: field = "exact" for exact match
-    # Template values will be auto-quoted by str_quote
-    startswith_expression: ClassVar[str] = 'LIKE({field}, {value}%)'
-    endswith_expression: ClassVar[str] = 'LIKE({field}, %{value})'
-    contains_expression: ClassVar[str] = 'LIKE({field}, %{value}%)'
-    wildcard_match_expression: ClassVar[str] = 'LIKE({field}, {value})'
-    
-    # Case-sensitive string matching with 'cased' modifier
-    # PPL LIKE function with third parameter set to true enables case-sensitive matching
-    # Format: LIKE(field, "pattern", true)
-    case_sensitive_match_expression: ClassVar[str] = '{field}={value}'
-    case_sensitive_startswith_expression: ClassVar[str] = 'LIKE({field}, {value}%, true)'
-    case_sensitive_endswith_expression: ClassVar[str] = 'LIKE({field}, %{value}, true)'
-    case_sensitive_contains_expression: ClassVar[str] = 'LIKE({field}, %{value}%, true)'
-    
-    # CIDR notation support
-    # PPL supports: cidrmatch(field, "cidr")
-    cidr_expression: ClassVar[str] = 'cidrmatch({field}, "{value}")'
-    
+    # PPL uses LIKE(field, "pattern") with % for wildcards
+    # PPL uses field="exact" for exact matches
+    startswith_expression: ClassVar[str | None] = "LIKE({field}, {value}%, false)"
+    endswith_expression: ClassVar[str | None] = "LIKE({field}, %{value}, false)"
+    contains_expression: ClassVar[str | None] = "LIKE({field}, %{value}%, false)"
+    wildcard_match_expression: ClassVar[str | None] = "LIKE({field}, {value}, false)"
+
+    # TODO fix this, needs to be deferred
     # Regular expressions in PPL
     # PPL supports: field match 'regex' or match(field, 'regex')
     # Note: Backslashes in regex are NOT escaped because they're already within single quotes
     # Only single quotes need escaping by doubling them
-    re_expression: ClassVar[str] = "match({field}, '{regex}')"
-    re_escape_char: ClassVar[str] = "'"
-    re_escape: ClassVar[tuple] = ("'",)
-    
-    # Comparison operators for numeric values
-    compare_op_expression: ClassVar[str] = "{field}{operator}{value}"
-    compare_operators: ClassVar[Dict[Any, str]] = {
+    re_expression: ClassVar[str | None] = "{regex}"
+    re_escape_char: ClassVar[str] = "\\"
+    re_escape: ClassVar[list[str]] = [
+        '"',
+    ]
+
+    # Case-sensitive string matching with 'cased' modifier
+    # PPL LIKE function with third parameter set to true enables case-sensitive matching
+    case_sensitive_match_expression: ClassVar[str | None] = "{field}={value}"
+    case_sensitive_startswith_expression: ClassVar[str | None] = (
+        "LIKE({field}, {value}%, true)"
+    )
+    case_sensitive_endswith_expression: ClassVar[str | None] = (
+        "LIKE({field}, %{value}, true)"
+    )
+    case_sensitive_contains_expression: ClassVar[str | None] = (
+        "LIKE({field}, %{value}%, true)"
+    )
+
+    # CIDR expressions
+    cidr_expression: ClassVar[str | None] = 'cidrmatch({field}, "{value}")'
+
+    # Numeric comparison operators
+    compare_op_expression: ClassVar[str | None] = "{field}{operator}{value}"
+    compare_operators: ClassVar[Dict[CompareOperators, str] | None] = {
         SigmaCompareExpression.CompareOperators.LT: "<",
         SigmaCompareExpression.CompareOperators.LTE: "<=",
         SigmaCompareExpression.CompareOperators.GT: ">",
         SigmaCompareExpression.CompareOperators.GTE: ">=",
     }
-    
-    # Field existence checks
-    field_exists_expression: ClassVar[str] = "isnotnull({field})"
-    field_not_exists_expression: ClassVar[str] = "isnull({field})"
-    
-    # Null value handling - in PPL use isnull() function
-    field_null_expression: ClassVar[str] = "isnull({field})"
-    
-    # Field-to-field comparison (fieldref modifier)
-    # PPL supports direct field comparison: field1=field2
-    field_equals_field_expression: ClassVar[str] = "{field1}={field2}"
-    
-    # List expressions (IN operator)
+
+    # Expression for comparing two event fields
+    field_equals_field_expression: ClassVar[str | None] = "{field1}={field2}"
+
+    # Null/None expressions
+    field_null_expression: ClassVar[str | None] = "isnull({field})"
+
+    # Field existence condition expressions.
+    field_exists_expression: ClassVar[str | None] = "isnotnull({field})"
+    field_not_exists_expression: ClassVar[str | None] = "isnull({field})"
+
+    # Field value in list
+    field_in_list_expression: ClassVar[str | None] = "{field} in ({list})"
+    or_in_operator: ClassVar[str | None] = "in"
+    list_separator: ClassVar[str | None] = ", "
     convert_or_as_in: ClassVar[bool] = True
     convert_and_as_in: ClassVar[bool] = False
     in_expressions_allow_wildcards: ClassVar[bool] = False
-    field_in_list_expression: ClassVar[str] = "{field} in ({list})"
-    or_in_operator: ClassVar[str] = "in"
-    list_separator: ClassVar[str] = ", "
-    
-    # Value expressions (for unbound values - used in keywords)
-    # Note: Don't add quotes here - pySigma adds them automatically via str_quote
-    unbound_value_str_expression: ClassVar[str] = '{value}'
-    unbound_value_num_expression: ClassVar[str] = '{value}'
-    
-    # Query expression template - just the condition, we add source in finish_query
-    query_expression: ClassVar[str] = "{query}"
-    
+
+    # Value not bound to a field
+    unbound_value_str_expression: ClassVar[str | None] = "query_string({value})"
+    unbound_value_num_expression: ClassVar[str | None] = "query_string({value})"
+
+    # Query finalization: appending and concatenating deferred query part
+    deferred_start: ClassVar[str | None] = "| "
+    deferred_separator: ClassVar[str | None] = " | "
+    deferred_only_query: ClassVar[str] = ""
+
     ### Correlation support ###
-    
     # Correlation methods supported by this backend
-    correlation_methods: ClassVar[Dict[str, str]] = {
+    correlation_methods: ClassVar[Dict[str, str] | None] = {
         "default": "Default method",
     }
-    
+    default_correlation_method: ClassVar[str] = "default"
+
+    ### Correlation rule templates
+    ## Correlation query frame
     # All correlation types use the same query structure:
     # {search} | stats {aggregate} | where {condition}
-    default_correlation_query: ClassVar[Dict[str, str]] = {
+    default_correlation_query: ClassVar[Dict[str, str] | None] = {
         "default": "{search} | stats {aggregate} | where {condition}"
     }
-    
-    # Joiner between multiple rule queries (unused but kept for compatibility)
-    correlation_search_multi_rule_query_expression_joiner: ClassVar[str] = " "
-    
-    # Aggregation expressions for different correlation types
-    default_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "count() as event_count by {groupby}"
+
+    ## Correlation query search phase
+    correlation_search_single_rule_expression: ClassVar[str | None] = "{query}"
+    correlation_search_multi_rule_expression: ClassVar[str | None] = (
+        "| multisearch {queries}"
+    )
+    correlation_search_multi_rule_query_expression: ClassVar[str | None] = (
+        '[search {query} | eval event_type="{ruleid}"{normalization}]'
+    )
+    correlation_search_multi_rule_query_expression_joiner: ClassVar[str | None] = " "
+    # Event field normalization expression.
+    correlation_search_field_normalization_expression: ClassVar[str | None] = (
+        " | rename {field} as {alias}"
+    )
+    correlation_search_field_normalization_expression_joiner: ClassVar[str | None] = " "
+
+    ## Correlation query aggregation phase
+    event_count_aggregation_expression: ClassVar[Dict[str, str] | None] = {
+        "default": "count() as event_count by span(@timestamp, {timespan}){groupby}"
     }
-    
-    event_count_aggregation_expression: ClassVar[Dict[str, str]] = default_aggregation_expression
-    
-    # Temporal correlations need to count distinct EventIDs to verify all rules matched
-    # and use span() for time-based grouping
-    temporal_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "dc(EventID) as unique_rules by span({time_field}, {timespan}), {groupby}"
+    value_count_aggregation_expression: ClassVar[Dict[str, str] | None] = {
+        "default": "dc({field}) as value_count by span(@timestamp, {timespan}){groupby}"
     }
-    temporal_ordered_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "dc(EventID) as unique_rules by span({time_field}, {timespan}), {groupby}"
+    temporal_aggregation_expression: ClassVar[Dict[str, str] | None] = {
+        "default": "dc(event_type) as unique_rules by span(@timestamp, {timespan}){groupby}"
     }
-    
-    value_count_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "dc({field}) as value_count by {groupby}"
-    }
-    
+
     # Group-by expression templates
-    groupby_expression: ClassVar[Dict[str, str]] = {"default": "{fields}"}
-    groupby_field_expression: ClassVar[Dict[str, str]] = {"default": "{field}"}
-    groupby_field_expression_joiner: ClassVar[Dict[str, str]] = {"default": ", "}
-    
+    groupby_expression: ClassVar[Dict[str, str] | None] = {"default": ", {fields}"}
+    groupby_field_expression: ClassVar[Dict[str, str] | None] = {"default": "{field}"}
+    groupby_field_expression_joiner: ClassVar[Dict[str, str] | None] = {"default": ", "}
+    groupby_expression_nofield: ClassVar[dict[str, str] | None] = {"default": ""}
+
     # Correlation condition expressions
-    default_condition_expression: ClassVar[Dict[str, str]] = {
+    event_count_condition_expression: ClassVar[Dict[str, str] | None] = {
         "default": "event_count {op} {count}",
     }
-    
-    event_count_condition_expression: ClassVar[Dict[str, str]] = default_condition_expression
-    
+
     # Temporal correlations check that all rules matched (distinct EventIDs)
-    temporal_condition_expression: ClassVar[Dict[str, str]] = {
-        "default": "unique_rules >= {rule_count}"
+    temporal_condition_expression: ClassVar[Dict[str, str] | None] = {
+        "default": "unique_rules {op} {count}"
     }
-    temporal_ordered_condition_expression: ClassVar[Dict[str, str]] = {
-        "default": "unique_rules >= {rule_count}"
-    }
-    
-    value_count_condition_expression: ClassVar[Dict[str, str]] = {
+
+    value_count_condition_expression: ClassVar[Dict[str, str] | None] = {
         "default": "value_count {op} {count}",
     }
-    
-    # Operator mapping for conditions
-    correlation_condition_op: ClassVar[Dict[str, str]] = {
-        "eq": "=", "ne": "!=", "lt": "<", "lte": "<=", "gt": ">", "gte": ">=",
-    }
-    
-    def __init__(
+
+    def __init__(  # pyright: ignore[reportInconsistentConstructor]
         self,
         processing_pipeline: Optional[ProcessingPipeline] = None,
         collect_errors: bool = False,
-        min_time: Optional[str] = None,
-        max_time: Optional[str] = None,
-        **backend_options: Dict,
+        min_time: str | None = None,
+        max_time: str | None = None,
+        custom_logsource: str | None = None,
+        **kwargs: Dict[str, Any],
     ):
         """
         Initialize the OpenSearch PPL backend.
-        
+
         Args:
             processing_pipeline: Optional processing pipeline for rule transformation
             collect_errors: If True, collect errors instead of raising them
             min_time: Minimum time filter (earliest). Examples: "-30d", "-7d", "2024-01-01T00:00:00"
             max_time: Maximum time filter (latest). Examples: "now", "2024-12-31T23:59:59"
-            **backend_options: Additional backend options:
-                - custom_logsource: Custom index pattern to override logsource-based pattern (default: None)
+            custom_logsource: Custom index pattern to override logsource-based pattern (default: None)
         """
-        super().__init__(processing_pipeline, collect_errors=collect_errors, **backend_options)
-        self._custom_logsource: Optional[str] = backend_options.get("custom_logsource", None)
-        self._time_field: str = "@timestamp"  # Default timestamp field for correlation rules
+        super().__init__(processing_pipeline, collect_errors=collect_errors, **kwargs)
+        self._custom_logsource: Optional[str] = custom_logsource
         self._min_time: Optional[str] = min_time
         self._max_time: Optional[str] = max_time
-    
+
     ### Regular rule conversion methods ###
-    
-    def finalize_query_default(
-        self, rule: SigmaRule, query: str, index: int, state: ConversionState
-    ) -> str:
-        """
-        Finalize the query by adding the source command.
-        
-        This method is called after the condition has been converted to add
-        PPL-specific elements like the source index pattern.
-        
-        Args:
-            rule: The Sigma rule being converted
-            query: The converted condition query
-            index: Query index (if rule generates multiple queries)
-            state: Conversion state
-            
-        Returns:
-            Complete PPL query with source command
-        """
-        # Correlation rules are already finalized
-        if isinstance(rule, SigmaCorrelationRule):
-            return query
-        
-        # Get index pattern from logsource
-        index_pattern = self._get_index_pattern(rule)
-        
-        # Build complete PPL query
-        # The query_expression template is already applied in finish_query
-        # We just need to ensure the state has the index
-        state.processing_state["index"] = index_pattern
-        
-        return query
-    
-    def finalize_output_default(self, queries: list[str]) -> list[str]:
-        """
-        Finalize the output by returning the list of queries.
-        
-        Args:
-            queries: List of generated PPL queries
-            
-        Returns:
-            List of PPL query strings
-        """
-        return queries
-    
+
     def _get_index_pattern(self, rule: SigmaRule) -> str:
         """
         Extract OpenSearch index pattern from Sigma logsource.
-        
+
         Maps Sigma logsource (product, category, service) to OpenSearch
         index patterns. Can be overridden with custom_logsource backend option
         or via custom attribute in the rule YAML.
-        
+
         Priority:
         1. Custom attribute in rule YAML (opensearch_ppl_index)
         2. Backend option (custom_logsource)
         3. Logsource-based mapping
-        
+
         Args:
             rule: Sigma rule containing logsource information
-            
+
         Returns:
             OpenSearch index pattern (e.g., "windows-process_creation-*" or custom pattern)
         """
         # Priority 1: Check for custom attribute in rule YAML
         # Custom attributes are nested under 'custom' key
-        if ('custom' in rule.custom_attributes and 
-            OpenSearchPPLCustomAttributes.INDEX.value in rule.custom_attributes['custom']):
-            return rule.custom_attributes['custom'][OpenSearchPPLCustomAttributes.INDEX.value]
-        
+        custom_attributes = rule.custom_attributes.get("opensearch_ppl_backend")
+        if custom_attributes is not None:
+            index = custom_attributes.get(OpenSearchPPLCustomAttributes.INDEX.value)
+            if index is not None:
+                return index
+
         # Priority 2: If custom logsource is provided via backend option, use it
         if self._custom_logsource:
             return self._custom_logsource
-        
+
         # Priority 3: Map logsource to index pattern
         logsource = rule.logsource
-        product = getattr(logsource, 'product', None)
-        category = getattr(logsource, 'category', None)
-        service = getattr(logsource, 'service', None)
-        
+
         # Build index pattern from logsource components
-        index_parts = []
-        
-        if product:
-            index_parts.append(product)
-        
-        if category:
-            index_parts.append(category)
-        
-        if service:
-            index_parts.append(service)
-        
-        # Build final index pattern
-        if index_parts:
-            return '-'.join(index_parts) + '-*'
-        else:
-            # Fallback to wildcard if no logsource specified
-            return '*'
-    
+        raw_index_parts: List[str | None] = [
+            logsource.product,
+            logsource.category,
+            logsource.service,
+        ]
+        index_parts: List[str] = [x for x in raw_index_parts if x is not None]
+
+        return "-".join([*index_parts, ""]) + "*"
+
     def finish_query(
-        self, rule: SigmaRule, query: str, state: ConversionState
+        self,
+        rule: SigmaRule | SigmaCorrelationRule,
+        query: str | DeferredQueryExpression,
+        state: ConversionState,
     ) -> str:
         """
         Finish the query before finalization.
-        
+
         This is called before finalize_query and is where we can add
         the search command and other PPL-specific structure.
-        
+
         Args:
             rule: The Sigma rule being converted
             query: The converted condition
             state: Conversion state
-            
+
         Returns:
             Query with PPL search command added
         """
+        if isinstance(rule, SigmaCorrelationRule):
+            return super().finish_query(rule, query, state)
+
         # Get index pattern from logsource
         index_pattern = self._get_index_pattern(rule)
-        
+
+        only_deferred = False
+        if isinstance(query, DeferredQueryExpression):
+            only_deferred = True
+
         # Handle deferred expressions (if any)
-        query = super().finish_query(rule, query, state)
-        
+        finished_query: str = super().finish_query(rule, query, state)
+
         # Fix LIKE expressions: move wildcards inside quotes
         # Handle all patterns in one comprehensive replacement
-        def fix_wildcards(match):
-            leading = match.group(1) or ''  # % before "
-            content = match.group(2)         # content between quotes
-            trailing = match.group(3) or ''  # % after "
+        def fix_wildcards(match: re.Match[str]) -> str:
+            leading = match.group(1) or ""  # % before "
+            content = match.group(2)  # content between quotes
+            trailing = match.group(3) or ""  # % after "
             return f'"{leading}{content}{trailing}"'
-        
-        query = re.sub(r'(%?)"([^"]*)\"(%?)', fix_wildcards, query)
-        
+
+        finished_query = re.sub(r'(%?)"(.*?)"(%?)', fix_wildcards, finished_query)
+
         # Build time modifiers using custom attributes or backend options
-        min_time = self._get_min_time(rule)
-        max_time = self._get_max_time(rule)
-        
-        # If we have time modifiers, use 'search' command syntax
-        # Otherwise, use 'source=... | where ...' syntax for backward compatibility
+        min_time = self._min_time
+        max_time = self._max_time
+
+        time_str = ""
         if min_time or max_time:
             # Build time modifiers for search command
-            time_modifiers = []
+            time_modifiers: List[str] = []
             if min_time:
-                time_modifiers.append(f"earliest={self._format_time_modifier(min_time)}")
+                time_modifiers.append(
+                    f"earliest={self._format_time_modifier(min_time)}"
+                )
             if max_time:
                 time_modifiers.append(f"latest={self._format_time_modifier(max_time)}")
-            
-            # Construct search command: search [time_modifiers] source=<index> | where <query>
-            # The query condition must come AFTER source with | where
-            time_str = " ".join(time_modifiers)
-            ppl_query = f"search {time_str} source={index_pattern} | where {query}"
-        else:
-            # Use traditional source | where syntax when no time filters
-            ppl_query = f"source={index_pattern} | where {query}"
-        
+
+            time_str = " ".join([*time_modifiers, ""])
+
+        # Construct search command: "[time_modifiers] source=<index> | where <query>"
+        # The query condition must come AFTER source with | where
+        ppl_query = f"{time_str}source={index_pattern} {'| where ' if not only_deferred else ''}{finished_query}"
+
         return ppl_query
-    
-    def _get_time_field(self, rule: SigmaRule) -> str:
-        """
-        Get the time field for the query.
-        
-        Priority:
-        1. Custom attribute in rule YAML (opensearch_ppl_time_field)
-        2. Backend default (@timestamp)
-        
-        Args:
-            rule: Sigma rule
-            
-        Returns:
-            Time field name
-        """
-        if ('custom' in rule.custom_attributes and 
-            OpenSearchPPLCustomAttributes.TIME_FIELD.value in rule.custom_attributes['custom']):
-            return rule.custom_attributes['custom'][OpenSearchPPLCustomAttributes.TIME_FIELD.value]
-        return self._time_field
-    
-    def _get_min_time(self, rule: SigmaRule) -> Optional[str]:
-        """
-        Get the minimum time filter.
-        
-        Priority:
-        1. Custom attribute in rule YAML (opensearch_ppl_min_time)
-        2. Backend option (min_time)
-        
-        Args:
-            rule: Sigma rule
-            
-        Returns:
-            Minimum time value or None
-        """
-        if ('custom' in rule.custom_attributes and 
-            OpenSearchPPLCustomAttributes.MIN_TIME.value in rule.custom_attributes['custom']):
-            return rule.custom_attributes['custom'][OpenSearchPPLCustomAttributes.MIN_TIME.value]
-        return self._min_time
-    
-    def _get_max_time(self, rule: SigmaRule) -> Optional[str]:
-        """
-        Get the maximum time filter.
-        
-        Priority:
-        1. Custom attribute in rule YAML (opensearch_ppl_max_time)
-        2. Backend option (max_time)
-        
-        Args:
-            rule: Sigma rule
-            
-        Returns:
-            Maximum time value or None
-        """
-        if ('custom' in rule.custom_attributes and 
-            OpenSearchPPLCustomAttributes.MAX_TIME.value in rule.custom_attributes['custom']):
-            return rule.custom_attributes['custom'][OpenSearchPPLCustomAttributes.MAX_TIME.value]
-        return self._max_time
-    
+
     def _format_time_modifier(self, time_str: str) -> str:
         """
         Format time modifier for PPL search command.
-        
+
         Args:
             time_str: Time string like "-30d", "now", "2024-01-01T00:00:00", "-1month@month"
-            
+
         Returns:
             Formatted time modifier for PPL search command
         """
         # Handle "now"
         if time_str.lower() == "now":
             return "now"
-        
+
         # Handle relative time with rounding like "-1month@month", "+1d@d"
         if "@" in time_str:
             # Wrap in quotes for time rounding expressions
             return f"'{time_str}'"
-        
+
         # Handle simple relative time like "-30d", "-7d", "-1h"
         if time_str.startswith("-") or time_str.startswith("+"):
             # Remove the dash/plus and keep the time unit as-is
             return time_str
-        
+
         # Handle absolute timestamps - wrap in quotes
         # PPL doesn't accept ISO8601 format with 'T', so convert to space
         # Convert "2024-01-01T00:00:00" to "2024-01-01 00:00:00"
-        time_str = time_str.replace('T', ' ')
+        time_str = time_str.replace("T", " ")
         return f"'{time_str}'"
-    
-    ### Correlation rule conversion methods ###
-    
-    def convert_rule(self, rule: SigmaRule, output_format: str = "default", callback=None) -> list[str]:
-        """
-        Convert a Sigma rule (regular or correlation) to PPL query.
-        
-        Args:
-            rule: The Sigma rule to convert (can be regular or correlation)
-            output_format: Output format to use
-            callback: Optional callback function
-            
-        Returns:
-            List of generated PPL queries
-        """
-        # Check if this is a correlation rule using isinstance
-        if isinstance(rule, SigmaCorrelationRule):
-            return self.convert_correlation_rule(rule, method="default")
-        else:
-            return super().convert_rule(rule, output_format, callback)
-    
-    def convert_correlation_rule(
-        self, rule: SigmaCorrelationRule, output_format: str = None, method: str = None, correlation_method: str = None
-    ) -> list[str]:
-        """
-        Convert a Sigma correlation rule to PPL query.
-        
-        Args:
-            rule: The correlation rule to convert
-            output_format: Output format (not used, for compatibility)
-            method: Correlation method (deprecated, use correlation_method)
-            correlation_method: Correlation method to use (default: "default")
-            
-        Returns:
-            List containing the generated PPL query
-        """
-        # Support both 'method' and 'correlation_method' for backward compatibility
-        final_method = correlation_method or method or "default"
-        return self.convert_correlation_rule_from_template(rule, rule.type, final_method)
-    
-    def convert_correlation_rule_from_template(
-        self,
-        rule: SigmaCorrelationRule,
-        correlation_type: SigmaCorrelationTypeLiteral,
-        method: str,
-    ) -> list[str]:
-        """
-        Convert correlation rule using templates.
-        
-        Orchestrates the three phases: Search, Aggregate, Condition.
-        
-        Args:
-            rule: The correlation rule to convert
-            correlation_type: Type of correlation (event_count, value_count, etc.)
-            method: Correlation method to use
-            
-        Returns:
-            List containing the generated PPL query
-        """
-        # Get template - all types use default_correlation_query now
-        template = self.default_correlation_query
-        
-        if template is None or method not in template:
-            raise SigmaConversionError(
-                f"Correlation method '{method}' is not supported by backend for "
-                f"correlation type '{correlation_type}'."
+
+    ### Deferred conversion methods ###
+
+    def convert_condition_field_eq_val_re(
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> PPLDeferredRegexExpression:
+        """Defer regular expression matching to pipelined regex command after main search expression."""
+
+        if cond.parent_condition_chain_contains(ConditionOR):
+            # While technically it could be implemented similar to the Splunk backend with rex,
+            # there is no equivalent to the _raw field in OpenSearch. Another option is to use
+            # multisearch and generate separate subqueries for each or, but that gets messy
+            # if you combine it with other Sigma conditions. Lastly, It might be easier to implement
+            # using the append command in PPL, but for now the effort is not worth it: regex
+            # are pretty inefficient/expensive and might not even work properly depending on the
+            # base field type (fields that are tokenized - i.e text - do not work properly).
+            raise NotImplementedError(
+                "OpenSearch PPL backend does not support regex expressions chained by OR"
             )
-        
-        # Generate the three phases
-        search = self.convert_correlation_search(rule)
-        aggregate = self.convert_correlation_aggregation_from_template(
-            rule, correlation_type, method, search
-        )
-        condition = self.convert_correlation_condition_from_template(
-            rule.condition, rule.rules, correlation_type, method, rule
-        )
-        
-        # Build final query from template
-        query = template[method].format(
-            search=search,
-            aggregate=aggregate,
-            condition=condition,
-        )
-        
-        # Note: Time filters are now applied individually per detection rule in convert_correlation_search()
-        # This allows both correlation-level and detection-level time filters
-        
-        return [query]
-    
-    def convert_correlation_search(self, rule: SigmaCorrelationRule, **kwargs) -> str:
-        """
-        Convert the search phase of a correlation rule.
-        
-        Uses OpenSearch 3.4+ multisearch command for correlation rules with multiple
-        subsearches, or a single search command if only one rule is referenced.
-        
-        Time filters logic:
-        - If detection rule has custom time attributes → use them for that specific rule
-        - If correlation rule has custom time attributes → apply to all detection rules without their own
-        
-        Args:
-            rule: The correlation rule
-            **kwargs: Additional arguments
-            
-        Returns:
-            Multisearch expression combining all referred detection rules, or a
-            single search query if only one rule is referenced
-        """
-        # Get correlation-level time filters (fallback for detection rules without their own)
-        corr_min_time = self._get_min_time(rule)
-        corr_max_time = self._get_max_time(rule)
-        
-        # Collect complete queries from all referred rules
-        subsearches = []
-        
-        for rule_reference in rule.rules:
-            referred_rule = rule_reference.rule
-            for query in referred_rule.get_conversion_result():
-                # Check if this detection rule has its own time attributes
-                detection_min_time = self._get_min_time(referred_rule)
-                detection_max_time = self._get_max_time(referred_rule)
-                
-                # Use detection rule's time filters if present, otherwise use correlation's
-                min_time = detection_min_time if detection_min_time else corr_min_time
-                max_time = detection_max_time if detection_max_time else corr_max_time
-                
-                # Apply time filters to this specific subsearch if needed
-                # Only apply if the query doesn't already have time filters (from detection rule)
-                needs_time_filters = (min_time or max_time) and not query.startswith("search ")
-                
-                if needs_time_filters:
-                    time_modifiers = []
-                    if min_time:
-                        time_modifiers.append(f"earliest={self._format_time_modifier(min_time)}")
-                    if max_time:
-                        time_modifiers.append(f"latest={self._format_time_modifier(max_time)}")
-                    
-                    time_str = " ".join(time_modifiers)
-                    
-                    # Add time modifiers to the query
-                    if query.startswith("source="):
-                        # Convert "source=... | where ..." to "search earliest=... source=... | where ..."
-                        query = f"search {time_str} {query}"
-                
-                # Store complete query for multisearch
-                subsearches.append(query)
-        
-        # If only one subsearch, return it directly (multisearch requires at least 2)
-        if len(subsearches) == 1:
-            query = subsearches[0]
-            if not query.startswith("search "):
-                query = f"search {query}"
-            return f"| {query}"
-        
-        # Use multisearch command for multiple subsearches
-        # Format: | multisearch [search source=index1 | where ...] [search source=index2 | where ...]
-        formatted_subsearches = []
-        for query in subsearches:
-            # Wrap each query in square brackets and ensure it starts with 'search'
-            if not query.startswith("search "):
-                query = f"search {query}"
-            formatted_subsearches.append(f"[{query}]")
-        
-        return "| multisearch " + " ".join(formatted_subsearches)
-    
-    def _format_timespan(self, timespan) -> str:
-        """Format timespan for PPL query ("5m", "30m", "2h")."""
-        if hasattr(timespan, 'spec'):
-            return str(timespan.spec)
-        elif hasattr(timespan, 'total_seconds'):
-            seconds = int(timespan.total_seconds())
-            if seconds % 3600 == 0:
-                return f"{seconds // 3600}h"
-            elif seconds % 60 == 0:
-                return f"{seconds // 60}m"
-            else:
-                return f"{seconds}s"
+
+        val = super().convert_condition_field_eq_val_re(cond, state)
+        if isinstance(val, str):
+            return PPLDeferredRegexExpression(
+                conversion_state=state, field=cond.field, value=val
+            )
         else:
-            return str(timespan)
-    
-    def convert_correlation_aggregation_from_template(
-        self,
-        rule: SigmaCorrelationRule,
-        correlation_type: SigmaCorrelationTypeLiteral,
-        method: str,
-        search: str,
-    ) -> str:
-        """Convert the aggregation phase of a correlation rule."""
-        templates = getattr(self, f"{correlation_type}_aggregation_expression", self.default_aggregation_expression)
-        template = templates[method]
-        
-        # Get field for value_count correlation
-        field = ""
-        if (correlation_type == "value_count" or 
-            correlation_type == SigmaCorrelationType.VALUE_COUNT) and rule.condition:
-            if hasattr(rule.condition, 'fieldref') and rule.condition.fieldref:
-                field = rule.condition.fieldref
-        
-        # Format timespan for temporal correlations
-        timespan = self._format_timespan(rule.timespan) if hasattr(rule, 'timespan') else "5m"
-        
-        return template.format(
-            groupby=self.convert_correlation_aggregation_groupby_from_template(rule.group_by, method),
-            field=field,
-            time_field=self._time_field,
-            timespan=timespan
-        )
-    
-    def convert_correlation_aggregation_groupby_from_template(
-        self, group_by: Optional[list[str]], method: str
-    ) -> str:
-        """Convert group-by fields to PPL format."""
-        if not group_by:
-            return ""
-        
-        fields = self.groupby_field_expression_joiner[method].join(
-            self.groupby_field_expression[method].format(field=field)
-            for field in group_by
-        )
-        
-        return self.groupby_expression[method].format(fields=fields)
-    
-    def convert_correlation_condition_from_template(
-        self,
-        condition: Any,
-        rules: list,
-        correlation_type: SigmaCorrelationTypeLiteral,
-        method: str,
-        rule: SigmaCorrelationRule,
-    ) -> str:
-        """Convert the condition phase of a correlation rule."""
-        templates = getattr(self, f"{correlation_type}_condition_expression", self.default_condition_expression)
-        template = templates[method]
-        
-        # For temporal correlations, we need to check that all rules matched
-        # So the count should be the number of rules in the correlation
-        if correlation_type in [SigmaCorrelationType.TEMPORAL, SigmaCorrelationType.TEMPORAL_ORDERED, "temporal", "temporal_ordered"]:
-            rule_count = len(rules)
-            return template.format(rule_count=rule_count)
-        
-        # For other correlation types, extract operator and count from condition
-        if hasattr(condition, 'op') and hasattr(condition, 'count'):
-            op_str = condition.op.name  # Get enum name ('GTE')
-            count = condition.count
-        elif isinstance(condition, dict):
-            op_str = list(condition.keys())[0].upper()
-            count = list(condition.values())[0]
-        else:
-            raise SigmaConversionError(f"Unsupported condition format: {condition}")
-        
-        # Map operator to PPL format
-        op_str_lower = op_str.lower()
-        if op_str_lower not in self.correlation_condition_op:
-            raise SigmaConversionError(f"Unsupported condition operator: {op_str}")
-        
-        op = self.correlation_condition_op[op_str_lower]
-        
-        # Get field if needed for value_count
-        field = ""
-        if correlation_type == "value_count" and hasattr(condition, 'fieldref'):
-            field = condition.fieldref or ""
-        
-        return template.format(op=op, count=count, field=field)
-    
+            # This should not be hit, but it's here to tame the type checker
+            raise SigmaValueError

--- a/tests/test_backend_opensearch_ppl.py
+++ b/tests/test_backend_opensearch_ppl.py
@@ -7,9 +7,11 @@ from sigma.backends.opensearch.opensearch_ppl import OpenSearchPPLBackend
 def os_ppl_backend():
     return OpenSearchPPLBackend()
 
+
 # ============================================================================
 # SIMPLE RULES TESTS
 # ============================================================================
+
 
 def test_automated_case_insensitive_match(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -29,7 +31,9 @@ def test_automated_case_insensitive_match(os_ppl_backend: OpenSearchPPLBackend):
                         - 'IpConfig'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "%WHOAMI%") OR LIKE(CommandLine, "%netstat%") OR LIKE(CommandLine, "%IpConfig%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(CommandLine, "%WHOAMI%", false) OR LIKE(CommandLine, "%netstat%", false) OR LIKE(CommandLine, "%IpConfig%", false)"""
+    ]
 
 
 def test_automated_cidr_network_range(os_ppl_backend: OpenSearchPPLBackend):
@@ -48,7 +52,9 @@ def test_automated_cidr_network_range(os_ppl_backend: OpenSearchPPLBackend):
                     DestinationIp|cidr: '192.168.1.0/24'
                 condition: selection
         """)
-    ) == ['source=windows-network_connection-* | where EventID=3 AND cidrmatch(DestinationIp, "192.168.1.0/24")']
+    ) == [
+        r"""source=windows-network_connection-* | where EventID=3 AND cidrmatch(DestinationIp, "192.168.1.0/24")"""
+    ]
 
 
 def test_automated_field_null_check(os_ppl_backend: OpenSearchPPLBackend):
@@ -67,7 +73,9 @@ def test_automated_field_null_check(os_ppl_backend: OpenSearchPPLBackend):
                     CommandLine: null
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where EventID=1 AND isnull(CommandLine)']
+    ) == [
+        r"""source=windows-process_creation-* | where EventID=1 AND isnull(CommandLine)"""
+    ]
 
 
 def test_automated_lateral_movement_psexec(os_ppl_backend: OpenSearchPPLBackend):
@@ -83,12 +91,14 @@ def test_automated_lateral_movement_psexec(os_ppl_backend: OpenSearchPPLBackend)
             detection:
                 selection:
                     Image|endswith: '\PsExec.exe'
-                    CommandLine|contains: '\\\'
+                    CommandLine|contains: '\\\\' # plain value \\
                 filter:
                     User|contains: 'SYSTEM'
                 condition: selection and not filter
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(Image, "%PsExec.exe") AND LIKE(CommandLine, "%%") AND NOT LIKE(User, "%SYSTEM%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(Image, "%\\PsExec.exe", false) AND LIKE(CommandLine, "%\\\\%", false) AND NOT LIKE(User, "%SYSTEM%", false)"""
+    ]
 
 
 def test_automated_linux_suspicious_bash_commands(os_ppl_backend: OpenSearchPPLBackend):
@@ -112,7 +122,9 @@ def test_automated_linux_suspicious_bash_commands(os_ppl_backend: OpenSearchPPLB
                         - 'chmod +x'
                 condition: selection
         """)
-    ) == ['source=linux-process_creation-* | where (LIKE(Image, "%/bash") OR LIKE(Image, "%/sh")) AND (LIKE(CommandLine, "%wget%") OR LIKE(CommandLine, "%curl%") OR LIKE(CommandLine, "%chmod +x%"))']
+    ) == [
+        r"""source=linux-process_creation-* | where (LIKE(Image, "%/bash", false) OR LIKE(Image, "%/sh", false)) AND (LIKE(CommandLine, "%wget%", false) OR LIKE(CommandLine, "%curl%", false) OR LIKE(CommandLine, "%chmod +x%", false))"""
+    ]
 
 
 def test_automated_logical_and_condition(os_ppl_backend: OpenSearchPPLBackend):
@@ -132,7 +144,9 @@ def test_automated_logical_and_condition(os_ppl_backend: OpenSearchPPLBackend):
                     CommandLine|contains: '/c'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where EventID=1 AND LIKE(Image, "%cmd.exe") AND LIKE(CommandLine, "%/c%")']
+    ) == [
+        r"""source=windows-process_creation-* | where EventID=1 AND LIKE(Image, "%\\cmd.exe", false) AND LIKE(CommandLine, "%/c%", false)"""
+    ]
 
 
 def test_automated_logical_complex_nested(os_ppl_backend: OpenSearchPPLBackend):
@@ -158,7 +172,9 @@ def test_automated_logical_complex_nested(os_ppl_backend: OpenSearchPPLBackend):
                     User|endswith: '\Administrator'
                 condition: (selection_image and selection_cmdline) and not filter_user
         """)
-    ) == ['source=windows-process_creation-* | where (LIKE(Image, "%powershell.exe") OR LIKE(Image, "%cmd.exe")) AND (LIKE(CommandLine, "%-enc%") OR LIKE(CommandLine, "%bypass%")) AND NOT LIKE(User, "%Administrator")']
+    ) == [
+        r"""source=windows-process_creation-* | where (LIKE(Image, "%\\powershell.exe", false) OR LIKE(Image, "%\\cmd.exe", false)) AND (LIKE(CommandLine, "%-enc%", false) OR LIKE(CommandLine, "%bypass%", false)) AND NOT LIKE(User, "%\\Administrator", false)"""
+    ]
 
 
 def test_automated_logical_multiple_selections(os_ppl_backend: OpenSearchPPLBackend):
@@ -185,7 +201,9 @@ def test_automated_logical_multiple_selections(os_ppl_backend: OpenSearchPPLBack
                     ParentImage|endswith: '\services.exe'
                 condition: (selection_suspicious_process and selection_suspicious_args) and not filter_legitimate
         """)
-    ) == ['source=windows-process_creation-* | where (LIKE(Image, "%net.exe") OR LIKE(Image, "%net1.exe")) AND (LIKE(CommandLine, "%user%") OR LIKE(CommandLine, "%group%") OR LIKE(CommandLine, "%localgroup%")) AND NOT LIKE(ParentImage, "%services.exe")']
+    ) == [
+        r"""source=windows-process_creation-* | where (LIKE(Image, "%\\net.exe", false) OR LIKE(Image, "%\\net1.exe", false)) AND (LIKE(CommandLine, "%user%", false) OR LIKE(CommandLine, "%group%", false) OR LIKE(CommandLine, "%localgroup%", false)) AND NOT LIKE(ParentImage, "%\\services.exe", false)"""
+    ]
 
 
 def test_automated_logical_not_condition(os_ppl_backend: OpenSearchPPLBackend):
@@ -206,7 +224,9 @@ def test_automated_logical_not_condition(os_ppl_backend: OpenSearchPPLBackend):
                     User|contains: 'SYSTEM'
                 condition: selection and not filter
         """)
-    ) == ['source=windows-process_creation-* | where EventID=1 AND LIKE(CommandLine, "%powershell%") AND NOT LIKE(User, "%SYSTEM%")']
+    ) == [
+        r"""source=windows-process_creation-* | where EventID=1 AND LIKE(CommandLine, "%powershell%", false) AND NOT LIKE(User, "%SYSTEM%", false)"""
+    ]
 
 
 def test_automated_logical_or_condition(os_ppl_backend: OpenSearchPPLBackend):
@@ -228,7 +248,9 @@ def test_automated_logical_or_condition(os_ppl_backend: OpenSearchPPLBackend):
                     Image|endswith: '\wscript.exe'
                 condition: selection_cmd or selection_powershell or selection_wscript
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(Image, "%cmd.exe") OR LIKE(Image, "%powershell.exe") OR LIKE(Image, "%wscript.exe")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(Image, "%\\cmd.exe", false) OR LIKE(Image, "%\\powershell.exe", false) OR LIKE(Image, "%\\wscript.exe", false)"""
+    ]
 
 
 def test_automated_mimikatz_execution(os_ppl_backend: OpenSearchPPLBackend):
@@ -252,7 +274,9 @@ def test_automated_mimikatz_execution(os_ppl_backend: OpenSearchPPLBackend):
                     OriginalFileName: 'mimikatz.exe'
                 condition: selection_cli or selection_image
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "%sekurlsa%") OR LIKE(CommandLine, "%logonpasswords%") OR LIKE(CommandLine, "%lsadump%") OR LIKE(Image, "%mimikatz.exe") AND OriginalFileName="mimikatz.exe"']
+    ) == [
+        r'''source=windows-process_creation-* | where LIKE(CommandLine, "%sekurlsa%", false) OR LIKE(CommandLine, "%logonpasswords%", false) OR LIKE(CommandLine, "%lsadump%", false) OR LIKE(Image, "%\\mimikatz.exe", false) AND OriginalFileName="mimikatz.exe"'''
+    ]
 
 
 def test_automated_modifier_base64(os_ppl_backend: OpenSearchPPLBackend):
@@ -270,7 +294,9 @@ def test_automated_modifier_base64(os_ppl_backend: OpenSearchPPLBackend):
                     CommandLine|base64|contains: 'powershell'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "%cG93ZXJzaGVsbA==%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(CommandLine, "%cG93ZXJzaGVsbA==%", false)"""
+    ]
 
 
 def test_automated_modifier_base64offset(os_ppl_backend: OpenSearchPPLBackend):
@@ -291,7 +317,9 @@ def test_automated_modifier_base64offset(os_ppl_backend: OpenSearchPPLBackend):
                         - '/bin/zsh'
                 condition: selection
         """)
-    ) == ['source=proxy-web-* | where LIKE(`c-uri`, "%L2Jpbi9iYXNo%") OR LIKE(`c-uri`, "%9iaW4vYmFza%") OR LIKE(`c-uri`, "%vYmluL2Jhc2%") OR LIKE(`c-uri`, "%L2Jpbi9za%") OR LIKE(`c-uri`, "%9iaW4vc2%") OR LIKE(`c-uri`, "%vYmluL3No%") OR LIKE(`c-uri`, "%L2Jpbi96c2%") OR LIKE(`c-uri`, "%9iaW4venNo%") OR LIKE(`c-uri`, "%vYmluL3pza%")']
+    ) == [
+        r"""source=proxy-web-* | where LIKE(`c-uri`, "%L2Jpbi9iYXNo%", false) OR LIKE(`c-uri`, "%9iaW4vYmFza%", false) OR LIKE(`c-uri`, "%vYmluL2Jhc2%", false) OR LIKE(`c-uri`, "%L2Jpbi9za%", false) OR LIKE(`c-uri`, "%9iaW4vc2%", false) OR LIKE(`c-uri`, "%vYmluL3No%", false) OR LIKE(`c-uri`, "%L2Jpbi96c2%", false) OR LIKE(`c-uri`, "%9iaW4venNo%", false) OR LIKE(`c-uri`, "%vYmluL3pza%", false)"""
+    ]
 
 
 def test_automated_modifier_cased(os_ppl_backend: OpenSearchPPLBackend):
@@ -309,7 +337,9 @@ def test_automated_modifier_cased(os_ppl_backend: OpenSearchPPLBackend):
                     CommandLine|cased|contains: 'CaseSensitiveValue'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "%CaseSensitiveValue%", true)']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(CommandLine, "%CaseSensitiveValue%", true)"""
+    ]
 
 
 def test_automated_modifier_contains_all(os_ppl_backend: OpenSearchPPLBackend):
@@ -330,7 +360,9 @@ def test_automated_modifier_contains_all(os_ppl_backend: OpenSearchPPLBackend):
                         - 'bypass'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "%powershell%") AND LIKE(CommandLine, "%-enc%") AND LIKE(CommandLine, "%bypass%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(CommandLine, "%powershell%", false) AND LIKE(CommandLine, "%-enc%", false) AND LIKE(CommandLine, "%bypass%", false)"""
+    ]
 
 
 def test_automated_modifier_endswith(os_ppl_backend: OpenSearchPPLBackend):
@@ -351,7 +383,9 @@ def test_automated_modifier_endswith(os_ppl_backend: OpenSearchPPLBackend):
                         - '.ps1'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(Image, "%.exe") OR LIKE(Image, "%.bat") OR LIKE(Image, "%.ps1")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(Image, "%.exe", false) OR LIKE(Image, "%.bat", false) OR LIKE(Image, "%.ps1", false)"""
+    ]
 
 
 def test_automated_modifier_exists_false(os_ppl_backend: OpenSearchPPLBackend):
@@ -369,7 +403,7 @@ def test_automated_modifier_exists_false(os_ppl_backend: OpenSearchPPLBackend):
                     User|exists: false
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where isnull(User)']
+    ) == [r"""source=windows-process_creation-* | where isnull(User)"""]
 
 
 def test_automated_modifier_exists_true(os_ppl_backend: OpenSearchPPLBackend):
@@ -387,7 +421,7 @@ def test_automated_modifier_exists_true(os_ppl_backend: OpenSearchPPLBackend):
                     User|exists: true
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where isnotnull(User)']
+    ) == [r"""source=windows-process_creation-* | where isnotnull(User)"""]
 
 
 def test_automated_modifier_fieldref(os_ppl_backend: OpenSearchPPLBackend):
@@ -405,7 +439,7 @@ def test_automated_modifier_fieldref(os_ppl_backend: OpenSearchPPLBackend):
                     User|fieldref: TargetUser
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where User=TargetUser']
+    ) == [r"""source=windows-process_creation-* | where User=TargetUser"""]
 
 
 def test_automated_modifier_gt(os_ppl_backend: OpenSearchPPLBackend):
@@ -423,7 +457,7 @@ def test_automated_modifier_gt(os_ppl_backend: OpenSearchPPLBackend):
                     ProcessId|gt: 1000
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where ProcessId>1000']
+    ) == [r"""source=windows-process_creation-* | where ProcessId>1000"""]
 
 
 def test_automated_modifier_gte(os_ppl_backend: OpenSearchPPLBackend):
@@ -441,7 +475,7 @@ def test_automated_modifier_gte(os_ppl_backend: OpenSearchPPLBackend):
                     ProcessId|gte: 1000
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where ProcessId>=1000']
+    ) == [r"""source=windows-process_creation-* | where ProcessId>=1000"""]
 
 
 def test_automated_modifier_lt(os_ppl_backend: OpenSearchPPLBackend):
@@ -459,7 +493,7 @@ def test_automated_modifier_lt(os_ppl_backend: OpenSearchPPLBackend):
                     ProcessId|lt: 5000
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where ProcessId<5000']
+    ) == [r"""source=windows-process_creation-* | where ProcessId<5000"""]
 
 
 def test_automated_modifier_lte(os_ppl_backend: OpenSearchPPLBackend):
@@ -477,7 +511,7 @@ def test_automated_modifier_lte(os_ppl_backend: OpenSearchPPLBackend):
                     ProcessId|lte: 5000
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where ProcessId<=5000']
+    ) == [r"""source=windows-process_creation-* | where ProcessId<=5000"""]
 
 
 def test_automated_modifier_startswith(os_ppl_backend: OpenSearchPPLBackend):
@@ -495,8 +529,9 @@ def test_automated_modifier_startswith(os_ppl_backend: OpenSearchPPLBackend):
                     TargetFilename|startswith: 'C:\Temp\'
                 condition: selection
         """)
-    ) == ['source=windows-file_event-* | where LIKE(TargetFilename, "C:Temp%")']
-
+    ) == [
+        r"""source=windows-file_event-* | where LIKE(TargetFilename, "C:\\Temp\\%", false)"""
+    ]
 
 
 def test_automated_modifier_wide_base64offset(os_ppl_backend: OpenSearchPPLBackend):
@@ -514,7 +549,9 @@ def test_automated_modifier_wide_base64offset(os_ppl_backend: OpenSearchPPLBacke
                     CommandLine|wide|base64offset|contains: 'ping'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "%cABpAG4AZw%") OR LIKE(CommandLine, "%AAaQBuAGcA%") OR LIKE(CommandLine, "%wAGkAbgBnA%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(CommandLine, "%cABpAG4AZw%", false) OR LIKE(CommandLine, "%AAaQBuAGcA%", false) OR LIKE(CommandLine, "%wAGkAbgBnA%", false)"""
+    ]
 
 
 def test_automated_modifier_windash(os_ppl_backend: OpenSearchPPLBackend):
@@ -534,7 +571,9 @@ def test_automated_modifier_windash(os_ppl_backend: OpenSearchPPLBackend):
                         - ' -f '
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "% -param-name %") OR LIKE(CommandLine, "% /param-name %") OR LIKE(CommandLine, "% –param-name %") OR LIKE(CommandLine, "% —param-name %") OR LIKE(CommandLine, "% ―param-name %") OR LIKE(CommandLine, "% -f %") OR LIKE(CommandLine, "% /f %") OR LIKE(CommandLine, "% –f %") OR LIKE(CommandLine, "% —f %") OR LIKE(CommandLine, "% ―f %")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(CommandLine, "% -param-name %", false) OR LIKE(CommandLine, "% /param-name %", false) OR LIKE(CommandLine, "% –param-name %", false) OR LIKE(CommandLine, "% —param-name %", false) OR LIKE(CommandLine, "% ―param-name %", false) OR LIKE(CommandLine, "% -f %", false) OR LIKE(CommandLine, "% /f %", false) OR LIKE(CommandLine, "% –f %", false) OR LIKE(CommandLine, "% —f %", false) OR LIKE(CommandLine, "% ―f %", false)"""
+    ]
 
 
 def test_automated_numeric_greater_than(os_ppl_backend: OpenSearchPPLBackend):
@@ -553,7 +592,7 @@ def test_automated_numeric_greater_than(os_ppl_backend: OpenSearchPPLBackend):
                     ProcessId|gt: 1000
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where EventID=1 AND ProcessId>1000']
+    ) == [r"""source=windows-process_creation-* | where EventID=1 AND ProcessId>1000"""]
 
 
 def test_automated_numeric_high_privilege(os_ppl_backend: OpenSearchPPLBackend):
@@ -572,7 +611,9 @@ def test_automated_numeric_high_privilege(os_ppl_backend: OpenSearchPPLBackend):
                     ProcessId|gt: 0
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where IntegrityLevel="System" AND ProcessId>0']
+    ) == [
+        r"""source=windows-process_creation-* | where IntegrityLevel="System" AND ProcessId>0"""
+    ]
 
 
 def test_automated_numeric_less_than(os_ppl_backend: OpenSearchPPLBackend):
@@ -591,7 +632,9 @@ def test_automated_numeric_less_than(os_ppl_backend: OpenSearchPPLBackend):
                     DestinationPort|lt: 1024
                 condition: selection
         """)
-    ) == ['source=windows-network_connection-* | where EventID=3 AND DestinationPort<1024']
+    ) == [
+        r"""source=windows-network_connection-* | where EventID=3 AND DestinationPort<1024"""
+    ]
 
 
 def test_automated_numeric_range_check(os_ppl_backend: OpenSearchPPLBackend):
@@ -611,7 +654,9 @@ def test_automated_numeric_range_check(os_ppl_backend: OpenSearchPPLBackend):
                     DestinationPort|lte: 9000
                 condition: selection
         """)
-    ) == ['source=windows-network_connection-* | where EventID=3 AND DestinationPort>=8000 AND DestinationPort<=9000']
+    ) == [
+        r"""source=windows-network_connection-* | where EventID=3 AND DestinationPort>=8000 AND DestinationPort<=9000"""
+    ]
 
 
 def test_automated_numeric_suspicious_port(os_ppl_backend: OpenSearchPPLBackend):
@@ -631,7 +676,9 @@ def test_automated_numeric_suspicious_port(os_ppl_backend: OpenSearchPPLBackend)
                     Initiated: 'true'
                 condition: selection
         """)
-    ) == ['source=windows-network_connection-* | where EventID=3 AND DestinationPort>=4444 AND Initiated="true"']
+    ) == [
+        r'''source=windows-network_connection-* | where EventID=3 AND DestinationPort>=4444 AND Initiated="true"'''
+    ]
 
 
 def test_automated_regex_base64_command(os_ppl_backend: OpenSearchPPLBackend):
@@ -649,7 +696,9 @@ def test_automated_regex_base64_command(os_ppl_backend: OpenSearchPPLBackend):
                     CommandLine|re: '(?i).*-e(nc(odedcommand)?|c)\s+[A-Za-z0-9+/]{50,}={0,2}.*'
                 condition: selection
         """)
-    ) == ["source=windows-process_creation-* | where match(CommandLine, '(?i).*-e(nc(odedcommand)?|c)\\s+[A-Za-z0-9+/]{50,}={0,2}.*')"]
+    ) == [
+        r'''source=windows-process_creation-* | regex CommandLine="(?i).*-e(nc(odedcommand)?|c)\\s+[A-Za-z0-9+/]{50,}={0,2}.*"'''
+    ]
 
 
 def test_automated_regex_pattern_match(os_ppl_backend: OpenSearchPPLBackend):
@@ -667,7 +716,9 @@ def test_automated_regex_pattern_match(os_ppl_backend: OpenSearchPPLBackend):
                     CommandLine|re: '.*powershell.*-[eE]nc.*'
                 condition: selection
         """)
-    ) == ["source=windows-process_creation-* | where match(CommandLine, '.*powershell.*-[eE]nc.*')"]
+    ) == [
+        r'''source=windows-process_creation-* | regex CommandLine=".*powershell.*-[eE]nc.*"'''
+    ]
 
 
 def test_automated_registry_key_modification(os_ppl_backend: OpenSearchPPLBackend):
@@ -688,7 +739,9 @@ def test_automated_registry_key_modification(os_ppl_backend: OpenSearchPPLBacken
                         - 'HKCU\Software\Microsoft\Windows\CurrentVersion\Run'
                 condition: selection
         """)
-    ) == ['source=windows-registry_event-* | where EventID=13 AND (LIKE(TargetObject, "HKLMSoftwareMicrosoftWindowsCurrentVersionRun%") OR LIKE(TargetObject, "HKCUSoftwareMicrosoftWindowsCurrentVersionRun%"))']
+    ) == [
+        r"""source=windows-registry_event-* | where EventID=13 AND (LIKE(TargetObject, "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run%", false) OR LIKE(TargetObject, "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run%", false))"""
+    ]
 
 
 def test_automated_scheduled_task_creation(os_ppl_backend: OpenSearchPPLBackend):
@@ -709,7 +762,9 @@ def test_automated_scheduled_task_creation(os_ppl_backend: OpenSearchPPLBackend)
                         - '/tn'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(Image, "%schtasks.exe") AND LIKE(CommandLine, "%/create%") AND LIKE(CommandLine, "%/tn%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(Image, "%\\schtasks.exe", false) AND LIKE(CommandLine, "%/create%", false) AND LIKE(CommandLine, "%/tn%", false)"""
+    ]
 
 
 def test_automated_special_chars_in_path(os_ppl_backend: OpenSearchPPLBackend):
@@ -730,7 +785,9 @@ def test_automated_special_chars_in_path(os_ppl_backend: OpenSearchPPLBackend):
                         - '\ProgramData\'
                 condition: selection
         """)
-    ) == ['source=windows-file_event-* | where LIKE(TargetFilename, "%UsersPublic%") OR LIKE(TargetFilename, "%AppDataRoaming%") OR LIKE(TargetFilename, "%ProgramData%")']
+    ) == [
+        r"""source=windows-file_event-* | where LIKE(TargetFilename, "%\\Users\\Public\\%", false) OR LIKE(TargetFilename, "%\\AppData\\Roaming\\%", false) OR LIKE(TargetFilename, "%\\ProgramData\\%", false)"""
+    ]
 
 
 def test_automated_suspicious_dns_query(os_ppl_backend: OpenSearchPPLBackend):
@@ -752,7 +809,9 @@ def test_automated_suspicious_dns_query(os_ppl_backend: OpenSearchPPLBackend):
                         - '.gq'
                 condition: selection
         """)
-    ) == ['source=windows-dns_query-* | where LIKE(QueryName, "%.tk") OR LIKE(QueryName, "%.ml") OR LIKE(QueryName, "%.ga") OR LIKE(QueryName, "%.gq")']
+    ) == [
+        r"""source=windows-dns_query-* | where LIKE(QueryName, "%.tk", false) OR LIKE(QueryName, "%.ml", false) OR LIKE(QueryName, "%.ga", false) OR LIKE(QueryName, "%.gq", false)"""
+    ]
 
 
 def test_automated_suspicious_service_install(os_ppl_backend: OpenSearchPPLBackend):
@@ -776,7 +835,9 @@ def test_automated_suspicious_service_install(os_ppl_backend: OpenSearchPPLBacke
                     CommandLine|contains: 'binpath'
                 condition: selection_image and selection_command and selection_binpath
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(Image, "%sc.exe") AND (LIKE(CommandLine, "%create%") OR LIKE(CommandLine, "%config%")) AND LIKE(CommandLine, "%binpath%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(Image, "%\\sc.exe", false) AND (LIKE(CommandLine, "%create%", false) OR LIKE(CommandLine, "%config%", false)) AND LIKE(CommandLine, "%binpath%", false)"""
+    ]
 
 
 def test_automated_suspicious_wmi_execution(os_ppl_backend: OpenSearchPPLBackend):
@@ -799,7 +860,33 @@ def test_automated_suspicious_wmi_execution(os_ppl_backend: OpenSearchPPLBackend
                         - '\cscript.exe'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(ParentImage, "%wmiprvse.exe") AND (LIKE(Image, "%powershell.exe") OR LIKE(Image, "%cmd.exe") OR LIKE(Image, "%wscript.exe") OR LIKE(Image, "%cscript.exe"))']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(ParentImage, "%\\wmiprvse.exe", false) AND (LIKE(Image, "%\\powershell.exe", false) OR LIKE(Image, "%\\cmd.exe", false) OR LIKE(Image, "%\\wscript.exe", false) OR LIKE(Image, "%\\cscript.exe", false))"""
+    ]
+
+
+def test_or_regex_not_implemented(os_ppl_backend: OpenSearchPPLBackend):
+    with pytest.raises(NotImplementedError):
+        os_ppl_backend.convert(
+            SigmaCollection.from_yaml(r"""
+            title: Suspicious WMI Execution
+            id: 00000006-0005-0005-0005-000000000005
+            status: test
+            description: Detects suspicious WMI process executions
+            logsource:
+                category: process_creation
+                product: windows
+            detection:
+                selection:
+                    - ParentImage|re: '.*\\wmiprvse.exe'
+                    - Image|re:
+                        - '.*\\powershell.exe'
+                        - '.*\\cmd.exe'
+                        - '.*\\wscript.exe'
+                        - '.*\\cscript.exe'
+                condition: selection
+            """)
+        )
 
 
 def test_automated_wildcard_pattern_match(os_ppl_backend: OpenSearchPPLBackend):
@@ -820,10 +907,14 @@ def test_automated_wildcard_pattern_match(os_ppl_backend: OpenSearchPPLBackend):
                         - 'cmd?.exe'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(CommandLine, "%malware%") OR LIKE(CommandLine, "%backdoor%") OR LIKE(CommandLine, "%cmd_.exe%")']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(CommandLine, "%malware%", false) OR LIKE(CommandLine, "%backdoor%", false) OR LIKE(CommandLine, "%cmd_.exe%", false)"""
+    ]
 
 
-def test_automated_windows_file_creation_sensitive(os_ppl_backend: OpenSearchPPLBackend):
+def test_automated_windows_file_creation_sensitive(
+    os_ppl_backend: OpenSearchPPLBackend,
+):
     assert os_ppl_backend.convert(
         SigmaCollection.from_yaml(r"""
             title: Sensitive File Creation
@@ -841,10 +932,14 @@ def test_automated_windows_file_creation_sensitive(os_ppl_backend: OpenSearchPPL
                         - 'C:\Windows\SysWOW64\'
                 condition: selection
         """)
-    ) == ['source=windows-file_event-* | where EventID=11 AND (LIKE(TargetFilename, "C:WindowsSystem32%") OR LIKE(TargetFilename, "C:WindowsSysWOW64%"))']
+    ) == [
+        r"""source=windows-file_event-* | where EventID=11 AND (LIKE(TargetFilename, "C:\\Windows\\System32\\%", false) OR LIKE(TargetFilename, "C:\\Windows\\SysWOW64\\%", false))"""
+    ]
 
 
-def test_automated_windows_network_connection_suspicious(os_ppl_backend: OpenSearchPPLBackend):
+def test_automated_windows_network_connection_suspicious(
+    os_ppl_backend: OpenSearchPPLBackend,
+):
     assert os_ppl_backend.convert(
         SigmaCollection.from_yaml(r"""
             title: Suspicious Network Connection
@@ -864,7 +959,9 @@ def test_automated_windows_network_connection_suspicious(os_ppl_backend: OpenSea
                     Initiated: 'true'
                 condition: selection
         """)
-    ) == ['source=windows-network_connection-* | where EventID=3 AND (DestinationPort in (4444, 5555, 8080)) AND Initiated="true"']
+    ) == [
+        r'''source=windows-network_connection-* | where EventID=3 AND (DestinationPort in (4444, 5555, 8080)) AND Initiated="true"'''
+    ]
 
 
 def test_automated_windows_process_creation_basic(os_ppl_backend: OpenSearchPPLBackend):
@@ -883,7 +980,9 @@ def test_automated_windows_process_creation_basic(os_ppl_backend: OpenSearchPPLB
                     Image: 'C:\Windows\System32\calc.exe'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where EventID=1 AND Image="C:WindowsSystem32calc.exe"']
+    ) == [
+        r'''source=windows-process_creation-* | where EventID=1 AND Image="C:\\Windows\\System32\\calc.exe"'''
+    ]
 
 
 def test_automated_windows_suspicious_powershell(os_ppl_backend: OpenSearchPPLBackend):
@@ -905,11 +1004,15 @@ def test_automated_windows_suspicious_powershell(os_ppl_backend: OpenSearchPPLBa
                         - '-NoProfile'
                 condition: selection
         """)
-    ) == ['source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") AND (LIKE(CommandLine, "%-EncodedCommand%") OR LIKE(CommandLine, "%-enc%") OR LIKE(CommandLine, "%-NoProfile%"))']
+    ) == [
+        r"""source=windows-process_creation-* | where LIKE(Image, "%\\powershell.exe", false) AND (LIKE(CommandLine, "%-EncodedCommand%", false) OR LIKE(CommandLine, "%-enc%", false) OR LIKE(CommandLine, "%-NoProfile%", false))"""
+    ]
+
 
 # ============================================================================
 # CORRELATION RULES TESTS
 # ============================================================================
+
 
 def test_correlation_account_manipulation(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -919,56 +1022,58 @@ name: user_account_created
 status: test
 description: Detects user account creation
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4720
-  condition: selection
+    selection:
+        EventID: 4720
+    condition: selection
 ---
 title: User Added to Privileged Group
 name: user_added_to_group
 status: test
 description: Detects user being added to a privileged group
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4732
-    TargetUserName:
-      - Administrators
-      - Domain Admins
-      - Enterprise Admins
-  condition: selection
+    selection:
+        EventID: 4732
+        TargetUserName:
+            - Administrators
+            - Domain Admins
+            - Enterprise Admins
+    condition: selection
 ---
 title: Rapid Account Creation and Privilege Escalation
 status: test
 description: Detects quick succession of account creation followed by adding the account to a privileged group
 correlation:
-  type: temporal
-  rules:
-    - user_account_created
-    - user_added_to_group
-  aliases:
-    user:
-      user_account_created: TargetUserName
-      user_added_to_group: MemberName
-  group-by:
-    - user
-  timespan: 5m
+    type: temporal
+    rules:
+        - user_account_created
+        - user_added_to_group
+    aliases:
+        user:
+            user_account_created: TargetUserName
+            user_added_to_group: MemberName
+    group-by:
+        - user
+    timespan: 5m
 tags:
-  - attack.persistence
-  - attack.privilege_escalation
-  - attack.t1136
-  - attack.t1098
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1136
+    - attack.t1098
 level: critical
 falsepositives:
-  - Legitimate administrative operations
-  - Automated provisioning systems
+    - Legitimate administrative operations
+    - Automated provisioning systems
+        """)
+    ) == [
+        r"""| multisearch [search source=windows-security-* | where EventID=4720 | eval event_type="user_account_created" | rename TargetUserName as user] [search source=windows-security-* | where EventID=4732 AND (TargetUserName in ("Administrators", "Domain Admins", "Enterprise Admins")) | eval event_type="user_added_to_group" | rename MemberName as user] | stats dc(event_type) as unique_rules by span(@timestamp, 5m), user | where unique_rules >= 2"""
+    ]
 
-""")
-    ) == ['| multisearch [search source=windows-security-* | where EventID=4720] [search source=windows-security-* | where EventID=4732 AND (TargetUserName in ("Administrators", "Domain Admins", "Enterprise Admins"))] | stats dc(EventID) as unique_rules by span(@timestamp, 5m), user | where unique_rules >= 2']
 
 def test_correlation_brute_force_detection(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -978,37 +1083,39 @@ name: failed_logon
 status: test
 description: Detects failed logon events on Windows systems.
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4625
-  filter:
-    SubjectUserName|endswith: $
-  condition: selection and not filter
+    selection:
+        EventID: 4625
+    filter:
+        SubjectUserName|endswith: $
+    condition: selection and not filter
 ---
 title: Multiple failed logons for a single user (possible brute force attack)
 status: test
 description: Detects multiple failed logon attempts within a short timeframe which may indicate a brute force attack
 correlation:
-  type: event_count
-  rules:
-    - failed_logon
-  group-by:
-    - TargetUserName
-    - TargetDomainName
-  timespan: 5m
-  condition:
-    gte: 10
+    type: event_count
+    rules:
+        - failed_logon
+    group-by:
+        - TargetUserName
+        - TargetDomainName
+    timespan: 5m
+    condition:
+        gte: 10
 tags:
-  - attack.credential_access
-  - attack.t1110
+    - attack.credential_access
+    - attack.t1110
 level: high
 falsepositives:
-  - User entering wrong password multiple times
+    - User entering wrong password multiple times
+        """)
+    ) == [
+        r"""source=windows-security-* | where EventID=4625 AND NOT LIKE(SubjectUserName, "%$", false) | stats count() as event_count by span(@timestamp, 5m), TargetUserName, TargetDomainName | where event_count >= 10"""
+    ]
 
-""")
-    ) == ['| search source=windows-security-* | where EventID=4625 AND NOT LIKE(SubjectUserName, "%$") | stats count() as event_count by TargetUserName, TargetDomainName | where event_count >= 10']
 
 def test_correlation_data_exfiltration(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -1018,57 +1125,59 @@ name: sensitive_file_access
 status: test
 description: Detects access to sensitive files and directories
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4663
-    ObjectName|contains:
-      - '\Users\'
-      - '\Documents\'
-      - '\Desktop\'
-      - 'confidential'
-      - 'secret'
-    AccessMask: '0x1'  # Read access
-  condition: selection
+    selection:
+        EventID: 4663
+        ObjectName|contains:
+            - '\Users\'
+            - '\Documents\'
+            - '\Desktop\'
+            - 'confidential'
+            - 'secret'
+        AccessMask: '0x1'  # Read access
+    condition: selection
 ---
 title: Large Data Transfer
 name: large_data_transfer
 status: test
 description: Detects large outbound network data transfers
 logsource:
-  category: network_connection
-  product: windows
+    category: network_connection
+    product: windows
 detection:
-  selection:
-    Initiated: 'true'
-    BytesSent|gte: 10485760  # 10 MB
-  condition: selection
+    selection:
+        Initiated: 'true'
+        BytesSent|gte: 10485760  # 10 MB
+    condition: selection
 ---
 title: Potential Data Exfiltration
 status: test
 description: Detects potential data exfiltration by correlating sensitive file access with large network transfers
 correlation:
-  type: temporal
-  rules:
-    - sensitive_file_access
-    - large_data_transfer
-  group-by:
-    - User
-    - ComputerName
-  timespan: 10m
+    type: temporal
+    rules:
+        - sensitive_file_access
+        - large_data_transfer
+    group-by:
+        - User
+        - ComputerName
+    timespan: 10m
 tags:
-  - attack.exfiltration
-  - attack.t1041
-  - attack.t1048
+    - attack.exfiltration
+    - attack.t1041
+    - attack.t1048
 level: high
 falsepositives:
-  - Legitimate file synchronization
-  - Backup operations
-  - Cloud storage services
+    - Legitimate file synchronization
+    - Backup operations
+    - Cloud storage services
+        """)
+    ) == [
+        r"""| multisearch [search source=windows-security-* | where EventID=4663 AND (LIKE(ObjectName, "%\\Users\\%", false) OR LIKE(ObjectName, "%\\Documents\\%", false) OR LIKE(ObjectName, "%\\Desktop\\%", false) OR LIKE(ObjectName, "%confidential%", false) OR LIKE(ObjectName, "%secret%", false)) AND AccessMask="0x1" | eval event_type="sensitive_file_access"] [search source=windows-network_connection-* | where Initiated="true" AND BytesSent>=10485760 | eval event_type="large_data_transfer"] | stats dc(event_type) as unique_rules by span(@timestamp, 10m), User, ComputerName | where unique_rules >= 2"""
+    ]
 
-""")
-    ) == ['| multisearch [search source=windows-security-* | where EventID=4663 AND (LIKE(ObjectName, "%Users%") OR LIKE(ObjectName, "%Documents%") OR LIKE(ObjectName, "%Desktop%") OR LIKE(ObjectName, "%confidential%") OR LIKE(ObjectName, "%secret%")) AND AccessMask="0x1"] [search source=windows-network_connection-* | where Initiated="true" AND BytesSent>=10485760] | stats dc(EventID) as unique_rules by span(@timestamp, 10m), User, ComputerName | where unique_rules >= 2']
 
 def test_correlation_lateral_movement_detection(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -1078,54 +1187,57 @@ name: remote_service_creation
 status: test
 description: Detects remote service creation which may indicate lateral movement
 logsource:
-  product: windows
-  service: system
+    product: windows
+    service: system
 detection:
-  selection:
-    EventID: 7045
-    ServiceFileName|contains:
-      - '\\\\*\\'
-      - 'ADMIN$'
-  condition: selection
+    selection:
+        EventID: 7045
+        ServiceFileName|contains:
+            - '\\\\*\\' # plain value \\<wildcard>\
+            - 'ADMIN$'
+    condition: selection
 ---
 title: Remote Process Creation
 name: remote_process_creation
 status: test
 description: Detects process creation from remote source
 logsource:
-  category: process_creation
-  product: windows
+    category: process_creation
+    product: windows
 detection:
-  selection:
-    ParentImage|endswith: '\\services.exe'
-    Image|contains:
-      - '\\cmd.exe'
-      - '\\powershell.exe'
-      - '\\wmic.exe'
-  condition: selection
+    selection:
+        ParentImage|endswith: '\services.exe'
+        Image|contains:
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\wmic.exe'
+    condition: selection
 ---
 title: Lateral Movement Activity
 status: test
 description: Detects potential lateral movement by correlating remote service creation with suspicious process execution
 correlation:
-  type: temporal
-  rules:
-    - remote_service_creation
-    - remote_process_creation
-  group-by:
-    - ComputerName
-  timespan: 2m
+    type: temporal
+    rules:
+        - remote_service_creation
+        - remote_process_creation
+    group-by:
+        - ComputerName
+    timespan: 2m
 tags:
-  - attack.lateral_movement
-  - attack.t1021
-  - attack.t1569
+    - attack.lateral_movement
+    - attack.t1021
+    - attack.t1569
 level: high
 falsepositives:
-  - Legitimate administrative activity
-  - Remote management tools
+    - Legitimate administrative activity
+    - Remote management tools
 
 """)
-    ) == ['| multisearch [search source=windows-system-* | where EventID=7045 AND (LIKE(ServiceFileName, "%%%") OR LIKE(ServiceFileName, "%ADMIN$%"))] [search source=windows-process_creation-* | where LIKE(ParentImage, "%services.exe") AND (LIKE(Image, "%cmd.exe%") OR LIKE(Image, "%powershell.exe%") OR LIKE(Image, "%wmic.exe%"))] | stats dc(EventID) as unique_rules by span(@timestamp, 2m), ComputerName | where unique_rules >= 2']
+    ) == [
+        r"""| multisearch [search source=windows-system-* | where EventID=7045 AND (LIKE(ServiceFileName, "%\\\\%\\%", false) OR LIKE(ServiceFileName, "%ADMIN$%", false)) | eval event_type="remote_service_creation"] [search source=windows-process_creation-* | where LIKE(ParentImage, "%\\services.exe", false) AND (LIKE(Image, "%\\cmd.exe%", false) OR LIKE(Image, "%\\powershell.exe%", false) OR LIKE(Image, "%\\wmic.exe%", false)) | eval event_type="remote_process_creation"] | stats dc(event_type) as unique_rules by span(@timestamp, 2m), ComputerName | where unique_rules >= 2"""
+    ]
+
 
 def test_correlation_password_spraying(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -1135,36 +1247,38 @@ name: failed_logon_event
 status: test
 description: Detects failed logon attempts
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4625
-  condition: selection
+    selection:
+        EventID: 4625
+    condition: selection
 ---
 title: Password Spraying Attack Detection
 status: test
 description: Detects password spraying attacks by identifying multiple failed logon attempts across different user accounts from the same source
 correlation:
-  type: value_count
-  rules:
-    - failed_logon_event
-  group-by:
-    - IpAddress
-  timespan: 30m
-  condition:
-    gte: 10
-    field: TargetUserName
+    type: value_count
+    rules:
+        - failed_logon_event
+    group-by:
+        - IpAddress
+    timespan: 30m
+    condition:
+        gte: 10
+        field: TargetUserName
 tags:
-  - attack.credential_access
-  - attack.t1110.003
+    - attack.credential_access
+    - attack.t1110.003
 level: high
 falsepositives:
-  - Misconfigured authentication systems
-  - Legitimate authentication attempts during account migration
-
+    - Misconfigured authentication systems
+    - Legitimate authentication attempts during account migration
 """)
-    ) == ['| search source=windows-security-* | where EventID=4625 | stats dc(TargetUserName) as value_count by IpAddress | where value_count >= 10']
+    ) == [
+        r"""source=windows-security-* | where EventID=4625 | stats dc(TargetUserName) as value_count by span(@timestamp, 30m), IpAddress | where value_count >= 10"""
+    ]
+
 
 def test_correlation_privileged_group_enumeration(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -1174,46 +1288,49 @@ name: privileged_group_enumeration
 status: stable
 description: Detects enumeration of high-privilege Active Directory groups
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4799
-    CallerProcessId: 0x0
-    TargetUserName:
-      - Administrators
-      - Remote Desktop Users
-      - Remote Management Users
-      - Distributed COM Users
-  condition: selection
+    selection:
+        EventID: 4799
+        CallerProcessId: 0x0
+        TargetUserName:
+            - Administrators
+            - Remote Desktop Users
+            - Remote Management Users
+            - Distributed COM Users
+    condition: selection
 level: informational
 falsepositives:
-  - Administrative activity
-  - Directory assessment tools
+    - Administrative activity
+    - Directory assessment tools
 ---
 title: Enumeration of multiple high-privilege groups by tools like BloodHound
 status: stable
 description: Detects enumeration of multiple high-privilege AD groups within a short time frame, which may indicate BloodHound or similar tool usage
 correlation:
-  type: value_count
-  rules:
-    - privileged_group_enumeration
-  group-by:
-    - SubjectUserName
-  timespan: 15m
-  condition:
-    gte: 4
-    field: TargetUserName
+    type: value_count
+    rules:
+        - privileged_group_enumeration
+    group-by:
+        - SubjectUserName
+    timespan: 15m
+    condition:
+        gte: 4
+        field: TargetUserName
 tags:
-  - attack.discovery
-  - attack.t1087
+    - attack.discovery
+    - attack.t1087
 level: high
 falsepositives:
-  - Administrative activity
-  - Directory assessment tools
+    - Administrative activity
+    - Directory assessment tools
 
 """)
-    ) == ['| search source=windows-security-* | where EventID=4799 AND CallerProcessId=0 AND (TargetUserName in ("Administrators", "Remote Desktop Users", "Remote Management Users", "Distributed COM Users")) | stats dc(TargetUserName) as value_count by SubjectUserName | where value_count >= 4']
+    ) == [
+        r"""source=windows-security-* | where EventID=4799 AND CallerProcessId=0 AND (TargetUserName in ("Administrators", "Remote Desktop Users", "Remote Management Users", "Distributed COM Users")) | stats dc(TargetUserName) as value_count by span(@timestamp, 15m), SubjectUserName | where value_count >= 4"""
+    ]
+
 
 def test_correlation_successful_brute_force(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
@@ -1223,49 +1340,54 @@ name: win_failed_logon
 status: test
 description: Detects failed logon events on Windows
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4625
-  condition: selection
+    selection:
+        EventID: 4625
+    condition: selection
 ---
 title: Windows Successful Logon
 name: win_successful_logon
 status: test
 description: Detects successful logon events on Windows
 logsource:
-  product: windows
-  service: security
+    product: windows
+    service: security
 detection:
-  selection:
-    EventID: 4624
-    LogonType: 3  # Network logon
-  condition: selection
+    selection:
+        EventID: 4624
+        LogonType: 3  # Network logon
+    condition: selection
 ---
 title: Successful Brute Force Attack Detection
 status: test
 description: Detects a successful brute force attack by correlating failed logons followed by a successful logon from the same source
 correlation:
-  type: temporal
-  rules:
-    - win_failed_logon
-    - win_successful_logon
-  group-by:
-    - IpAddress
-    - TargetUserName
-  timespan: 10m
+    type: temporal
+    rules:
+        - win_failed_logon
+        - win_successful_logon
+    group-by:
+        - IpAddress
+        - TargetUserName
+    timespan: 10m
 tags:
-  - attack.credential_access
-  - attack.t1110
+    - attack.credential_access
+    - attack.t1110
 level: critical
 falsepositives:
-  - Users legitimately entering wrong password before successful login
+    - Users legitimately entering wrong password before successful login
 
 """)
-    ) == ['| multisearch [search source=windows-security-* | where EventID=4625] [search source=windows-security-* | where EventID=4624 AND LogonType=3] | stats dc(EventID) as unique_rules by span(@timestamp, 10m), IpAddress, TargetUserName | where unique_rules >= 2']
+    ) == [
+        r"""| multisearch [search source=windows-security-* | where EventID=4625 | eval event_type="win_failed_logon"] [search source=windows-security-* | where EventID=4624 AND LogonType=3 | eval event_type="win_successful_logon"] | stats dc(event_type) as unique_rules by span(@timestamp, 10m), IpAddress, TargetUserName | where unique_rules >= 2"""
+    ]
 
-def test_correlation_suspicious_network_connection(os_ppl_backend: OpenSearchPPLBackend):
+
+def test_correlation_suspicious_network_connection(
+    os_ppl_backend: OpenSearchPPLBackend,
+):
     assert os_ppl_backend.convert(
         SigmaCollection.from_yaml(r"""
 title: Suspicious Process Execution
@@ -1273,129 +1395,95 @@ name: suspicious_process
 status: test
 description: Detects execution of commonly abused system binaries
 logsource:
-  category: process_creation
-  product: windows
+    category: process_creation
+    product: windows
 detection:
-  selection:
-    Image|endswith:
-      - '\\powershell.exe'
-      - '\\cmd.exe'
-      - '\\wscript.exe'
-      - '\\cscript.exe'
-      - '\\regsvr32.exe'
-  condition: selection
+    selection:
+        Image|endswith:
+            - '\powershell.exe'
+            - '\cmd.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
+            - '\regsvr32.exe'
+    condition: selection
 ---
 title: Network Connection to Suspicious Port
 name: suspicious_network_connection
 status: test
 description: Detects network connections to commonly used C2 or suspicious ports
 logsource:
-  category: network_connection
-  product: windows
+    category: network_connection
+    product: windows
 detection:
-  selection:
-    Initiated: 'true'
-    DestinationPort:
-      - 4444
-      - 5555
-      - 8080
-      - 9999
-  condition: selection
+    selection:
+        Initiated: 'true'
+        DestinationPort:
+            - 4444
+            - 5555
+            - 8080
+            - 9999
+    condition: selection
 ---
 title: Process Execution with Suspicious Network Activity
 status: test
 description: Correlates suspicious process execution with network connections to potentially malicious ports
 correlation:
-  type: temporal
-  rules:
-    - suspicious_process
-    - suspicious_network_connection
-  aliases:
-    process:
-      suspicious_process: ProcessId
-      suspicious_network_connection: ProcessId
-  group-by:
-    - process
-    - ComputerName
-  timespan: 60s
+    type: temporal
+    rules:
+        - suspicious_process
+        - suspicious_network_connection
+    aliases:
+        process:
+            suspicious_process: ProcessId
+            suspicious_network_connection: ProcessId
+    group-by:
+        - process
+        - ComputerName
+    timespan: 60s
 tags:
-  - attack.execution
-  - attack.command_and_control
-  - attack.t1059
-  - attack.t1071
+    - attack.execution
+    - attack.command_and_control
+    - attack.t1059
+    - attack.t1071
 level: high
 falsepositives:
-  - Legitimate administrative scripts
-  - Development and testing activities
+    - Legitimate administrative scripts
+    - Development and testing activities
 
 """)
-    ) == ['| multisearch [search source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") OR LIKE(Image, "%cmd.exe") OR LIKE(Image, "%wscript.exe") OR LIKE(Image, "%cscript.exe") OR LIKE(Image, "%regsvr32.exe")] [search source=windows-network_connection-* | where Initiated="true" AND (DestinationPort in (4444, 5555, 8080, 9999))] | stats dc(EventID) as unique_rules by span(@timestamp, 60s), process, ComputerName | where unique_rules >= 2']
+    ) == [
+        r"""| multisearch [search source=windows-process_creation-* | where LIKE(Image, "%\\powershell.exe", false) OR LIKE(Image, "%\\cmd.exe", false) OR LIKE(Image, "%\\wscript.exe", false) OR LIKE(Image, "%\\cscript.exe", false) OR LIKE(Image, "%\\regsvr32.exe", false) | eval event_type="suspicious_process" | rename ProcessId as process] [search source=windows-network_connection-* | where Initiated="true" AND (DestinationPort in (4444, 5555, 8080, 9999)) | eval event_type="suspicious_network_connection" | rename ProcessId as process] | stats dc(event_type) as unique_rules by span(@timestamp, 60s), process, ComputerName | where unique_rules >= 2"""
+    ]
+
 
 # ============================================================================
 # CUSTOM ATTRIBUTE TESTS
 # ============================================================================
 
 
-def test_custom_attr_all_attributes(os_ppl_backend: OpenSearchPPLBackend):
+def test_custom_attr_logsource(os_ppl_backend: OpenSearchPPLBackend):
     assert os_ppl_backend.convert(
         SigmaCollection.from_yaml(r"""
-title: Test All Custom Attributes
-id: 10000004-0000-0000-0000-000000000004
-status: test
-description: Test using all custom attributes in one rule
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-custom:
-  opensearch_ppl_index: "complete-test-*"
-  opensearch_ppl_min_time: "-14d"
-  opensearch_ppl_max_time: "now"
-
-""")
-    ) == ['search earliest=-14d latest=now source=complete-test-* | where CommandLine="test.exe"']
+            title: Test All Custom Attributes
+            id: 10000004-0000-0000-0000-000000000004
+            status: test
+            description: Test using all custom attributes in one rule
+            logsource:
+                product: windows
+                category: process_creation
+            detection:
+                selection:
+                    CommandLine: test.exe
+                condition: selection
+            opensearch_ppl_backend:
+                index: "complete-test-*"
+        """)
+    ) == [r'''source=complete-test-* | where CommandLine="test.exe"''']
 
 
-def test_custom_attr_correlation_event_count(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Detection Rule - Failed Login
-id: 10000100-0000-0000-0000-000000000001
-status: test
-description: Detect failed login attempts
-logsource:
-  product: windows
-  category: security
-detection:
-  selection:
-    EventID: 4625
-  condition: selection
----
-title: Correlation - Brute Force Detection with Time Filter
-id: 10000101-0000-0000-0000-000000000001
-status: test
-description: Test event_count correlation with custom time attributes
-correlation:
-  type: event_count
-  rules:
-    - 10000100-0000-0000-0000-000000000001
-  group-by:
-    - SourceIP
-  timespan: 5m
-  condition:
-    gte: 5
-custom:
-  opensearch_ppl_min_time: "-24h"
-  opensearch_ppl_max_time: "now"
-
-""")
-    ) == ['| search earliest=-24h latest=now source=windows-security-* | where EventID=4625 | stats count() as event_count by SourceIP | where event_count >= 5']
-
-
-def test_custom_attr_correlation_mixed_times(os_ppl_backend: OpenSearchPPLBackend):
+def test_custom_attr_correlation_mixed_logsource(
+    os_ppl_backend: OpenSearchPPLBackend,
+):
     assert os_ppl_backend.convert(
         SigmaCollection.from_yaml(r"""
 title: Detection Rule 1 - With Own Time Filter
@@ -1403,285 +1491,56 @@ id: 10000400-0000-0000-0000-000000000004
 status: test
 description: Detection rule with its own custom time attributes
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:
-    CommandLine|contains: 'malware'
-  condition: selection
-custom:
-  opensearch_ppl_min_time: "-7d"
-  opensearch_ppl_max_time: "now"
+    selection:
+        CommandLine|contains: 'malware'
+    condition: selection
+opensearch_ppl_backend:
+    index: windows-*
 ---
 title: Detection Rule 2 - No Time Filter
 id: 10000401-0000-0000-0000-000000000004
 status: test
 description: Detection rule without custom time attributes (will inherit from correlation)
 logsource:
-  product: windows
-  category: network_connection
+    product: windows
+    category: network_connection
 detection:
-  selection:
-    DestinationPort: 443
-  condition: selection
+    selection:
+        DestinationPort: 443
+    condition: selection
+opensearch_ppl_backend:
+    index: windows-network-*
 ---
 title: Correlation - Mixed Time Filters
 id: 10000402-0000-0000-0000-000000000004
 status: test
 description: Test temporal correlation with mixed time filters - one detection rule has its own, one inherits
 correlation:
-  type: temporal
-  rules:
-    - 10000400-0000-0000-0000-000000000004
-    - 10000401-0000-0000-0000-000000000004
-  group-by:
-    - Computer
-  timespan: 5m
-custom:
-  opensearch_ppl_min_time: "-30d"
-  opensearch_ppl_max_time: "now"
+    type: temporal
+    rules:
+        - 10000400-0000-0000-0000-000000000004
+        - 10000401-0000-0000-0000-000000000004
+    group-by:
+        - Computer
+    timespan: 5m
+        """)
+    ) == [
+        r"""| multisearch [search source=windows-* | where LIKE(CommandLine, "%malware%", false) | eval event_type="10000400-0000-0000-0000-000000000004"] [search source=windows-network-* | where DestinationPort=443 | eval event_type="10000401-0000-0000-0000-000000000004"] | stats dc(event_type) as unique_rules by span(@timestamp, 5m), Computer | where unique_rules >= 2"""
+    ]
 
-""")
-    ) == ['| multisearch [search earliest=-7d latest=now source=windows-process_creation-* | where LIKE(CommandLine, "%malware%")] [search earliest=-30d latest=now source=windows-network_connection-* | where DestinationPort=443] | stats dc(EventID) as unique_rules by span(@timestamp, 5m), Computer | where unique_rules >= 2']
-
-
-def test_custom_attr_correlation_temporal(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Detection Rule - Suspicious Process
-id: 10000300-0000-0000-0000-000000000003
-status: test
-description: Detect suspicious process execution
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine|contains: 'suspicious'
-  condition: selection
----
-title: Detection Rule - Network Connection
-id: 10000301-0000-0000-0000-000000000003
-status: test
-description: Detect network connections
-logsource:
-  product: windows
-  category: network_connection
-detection:
-  selection:
-    Initiated: 'true'
-  condition: selection
----
-title: Correlation - Temporal Sequence with Absolute Time
-id: 10000302-0000-0000-0000-000000000003
-status: test
-description: Test temporal correlation with absolute timestamps
-correlation:
-  type: temporal
-  rules:
-    - 10000300-0000-0000-0000-000000000003
-    - 10000301-0000-0000-0000-000000000003
-  group-by:
-    - Computer
-  timespan: 2m
-custom:
-  opensearch_ppl_min_time: "2026-02-01 00:00:00"
-  opensearch_ppl_max_time: "2026-02-28 23:59:59"
-
-""")
-    ) == ['| multisearch [search earliest=\'2026-02-01 00:00:00\' latest=\'2026-02-28 23:59:59\' source=windows-process_creation-* | where LIKE(CommandLine, "%suspicious%")] [search earliest=\'2026-02-01 00:00:00\' latest=\'2026-02-28 23:59:59\' source=windows-network_connection-* | where Initiated="true"] | stats dc(EventID) as unique_rules by span(@timestamp, 2m), Computer | where unique_rules >= 2']
-
-
-def test_custom_attr_correlation_value_count(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Detection Rule - PowerShell Execution
-id: 10000200-0000-0000-0000-000000000002
-status: test
-description: Detect PowerShell execution
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-  condition: selection
----
-title: Correlation - Distinct PowerShell Commands with Time Rounding
-id: 10000201-0000-0000-0000-000000000002
-status: test
-description: Test value_count correlation with time rounding modifiers
-correlation:
-  type: value_count
-  rules:
-    - 10000200-0000-0000-0000-000000000002
-  group-by:
-    - User
-  timespan: 10m
-  condition:
-    field: CommandLine
-    gte: 3
-custom:
-  opensearch_ppl_min_time: "-1month@month"
-  opensearch_ppl_max_time: "+1d@d"
-
-""")
-    ) == ['| search earliest=\'-1month@month\' latest=\'+1d@d\' source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") | stats dc(CommandLine) as value_count by User | where value_count >= 3']
-
-
-def test_custom_attr_custom_index(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test Custom Index Attribute
-id: 10000001-0000-0000-0000-000000000001
-status: test
-description: Test that opensearch_ppl_index custom attribute overrides default index pattern
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-custom:
-  opensearch_ppl_index: "my-custom-index-*"
-
-""")
-    ) == ['source=my-custom-index-* | where CommandLine="test.exe"']
-
-
-def test_custom_attr_no_attributes(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test No Custom Attributes
-id: 10000005-0000-0000-0000-000000000005
-status: test
-description: Test that without custom attributes, backend uses defaults
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-
-""")
-    ) == ['source=windows-process_creation-* | where CommandLine="test.exe"']
-
-
-def test_custom_attr_partial_attributes(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test Partial Custom Attributes
-id: 10000006-0000-0000-0000-000000000006
-status: test
-description: Test with only some custom attributes
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-custom:
-  opensearch_ppl_index: "partial-test-*"
-
-""")
-    ) == ['source=partial-test-* | where CommandLine="test.exe"']
-
-
-def test_custom_attr_time_absolute(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test Absolute Time Range
-id: 10000008-0000-0000-0000-000000000008
-status: test
-description: Test absolute time ranges
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-custom:
-  opensearch_ppl_min_time: "2024-01-15 10:00:00"
-  opensearch_ppl_max_time: "2024-01-15 16:00:00"
-
-""")
-    ) == ['search earliest=\'2024-01-15 10:00:00\' latest=\'2024-01-15 16:00:00\' source=windows-process_creation-* | where CommandLine="test.exe"']
-
-
-def test_custom_attr_time_min_max(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test Custom Min and Max Time
-id: 10000003-0000-0000-0000-000000000003
-status: test
-description: Test that opensearch_ppl_min_time and opensearch_ppl_max_time work
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-custom:
-  opensearch_ppl_min_time: "-30d"
-  opensearch_ppl_max_time: "now"
-
-""")
-    ) == ['search earliest=-30d latest=now source=windows-process_creation-* | where CommandLine="test.exe"']
-
-
-def test_custom_attr_time_modifier_simple(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test Time Modifier Syntax
-id: 10000002-0000-0000-0000-000000000002
-status: test
-description: Test that time modifiers use PPL earliest/latest syntax
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-custom:
-  opensearch_ppl_min_time: "-7d"
-
-""")
-    ) == ['search earliest=-7d source=windows-process_creation-* | where CommandLine="test.exe"']
-
-
-def test_custom_attr_time_rounding(os_ppl_backend: OpenSearchPPLBackend):
-    assert os_ppl_backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test Time Rounding
-id: 10000007-0000-0000-0000-000000000007
-status: test
-description: Test time modifiers with rounding
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    CommandLine: test.exe
-  condition: selection
-custom:
-  opensearch_ppl_min_time: "-1month@month"
-  opensearch_ppl_max_time: "+1d@d"
-
-""")
-    ) == ['search earliest=\'-1month@month\' latest=\'+1d@d\' source=windows-process_creation-* | where CommandLine="test.exe"']
 
 # ============================================================================
 # OPTION TESTS
 # ============================================================================
 
-def test_option_combined_options():
-    backend = OpenSearchPPLBackend(custom_logsource='security-logs-*', min_time='-24h', max_time='now')
+
+def test_backend_option_logsource_time():
+    backend = OpenSearchPPLBackend(
+        custom_logsource="security-logs-*", min_time="-24h", max_time="now"
+    )
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
 title: Test Combined Options
@@ -1691,20 +1550,22 @@ description: Test rule with custom logsource AND time filters
 author: Adrian
 date: 2026/02/28
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-    CommandLine|contains: 'Invoke-'
-  condition: selection
+    selection:
+        Image|endswith: '\powershell.exe'
+        CommandLine|contains: 'Invoke-'
+    condition: selection
 level: medium
+        """)
+    ) == [
+        r"""earliest=-24h latest=now source=security-logs-* | where LIKE(Image, "%\\powershell.exe", false) AND LIKE(CommandLine, "%Invoke-%", false)"""
+    ]
 
-""")
-    ) == ['search earliest=-24h latest=now source=security-logs-* | where LIKE(Image, "%powershell.exe") AND LIKE(CommandLine, "%Invoke-%")']
 
-def test_option_correlation_event_count():
-    backend = OpenSearchPPLBackend(min_time='-24h', max_time='now')
+def test_backend_option_correlation_event_count_relative_time():
+    backend = OpenSearchPPLBackend(min_time="-24h", max_time="now")
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
 title: Detection Rule - Failed Login
@@ -1714,12 +1575,12 @@ description: Detect failed login attempts
 author: Adrian
 date: 2026/03/01
 logsource:
-  product: windows
-  category: security
+    product: windows
+    category: security
 detection:
-  selection:
-    EventID: 4625
-  condition: selection
+    selection:
+        EventID: 4625
+    condition: selection
 level: high
 ---
 title: Correlation - Brute Force Detection
@@ -1729,21 +1590,25 @@ description: Test event_count correlation with backend options
 author: Adrian
 date: 2026/03/01
 correlation:
-  type: event_count
-  rules:
-    - 20000100-0000-0000-0000-000000000001
-  group-by:
-    - SourceIP
-  timespan: 5m
-  condition:
-    gte: 5
+    type: event_count
+    rules:
+        - 20000100-0000-0000-0000-000000000001
+    group-by:
+        - SourceIP
+    timespan: 5m
+    condition:
+        gte: 5
 level: critical
+        """)
+    ) == [
+        r"""earliest=-24h latest=now source=windows-security-* | where EventID=4625 | stats count() as event_count by span(@timestamp, 5m), SourceIP | where event_count >= 5"""
+    ]
 
-""")
-    ) == ['| search earliest=-24h latest=now source=windows-security-* | where EventID=4625 | stats count() as event_count by SourceIP | where event_count >= 5']
 
-def test_option_correlation_temporal():
-    backend = OpenSearchPPLBackend(min_time='2026-02-01T00:00:00', max_time='2026-02-28T23:59:59')
+def test_backend_option_correlation_temporal_absolute_time():
+    backend = OpenSearchPPLBackend(
+        min_time="2026-02-01T00:00:00", max_time="2026-02-28T23:59:59"
+    )
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
 title: Detection Rule 1 - Suspicious Process
@@ -1753,12 +1618,12 @@ description: Detect suspicious process execution
 author: Adrian
 date: 2026/03/01
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:
-    CommandLine|contains: 'suspicious'
-  condition: selection
+    selection:
+        CommandLine|contains: 'suspicious'
+    condition: selection
 level: medium
 ---
 title: Detection Rule 2 - Network Connection
@@ -1768,12 +1633,12 @@ description: Detect network connection initiated
 author: Adrian
 date: 2026/03/01
 logsource:
-  product: windows
-  category: network_connection
+    product: windows
+    category: network_connection
 detection:
-  selection:
-    Initiated: 'true'
-  condition: selection
+    selection:
+        Initiated: 'true'
+    condition: selection
 level: low
 ---
 title: Correlation - Temporal Correlation
@@ -1783,20 +1648,22 @@ description: Test temporal correlation with backend options
 author: Adrian
 date: 2026/03/01
 correlation:
-  type: temporal
-  rules:
-    - 20000300-0000-0000-0000-000000000003
-    - 20000301-0000-0000-0000-000000000003
-  group-by:
-    - Computer
-  timespan: 2m
+    type: temporal
+    rules:
+        - 20000300-0000-0000-0000-000000000003
+        - 20000301-0000-0000-0000-000000000003
+    group-by:
+        - Computer
+    timespan: 2m
 level: high
+        """)
+    ) == [
+        r"""| multisearch [search earliest='2026-02-01 00:00:00' latest='2026-02-28 23:59:59' source=windows-process_creation-* | where LIKE(CommandLine, "%suspicious%", false) | eval event_type="20000300-0000-0000-0000-000000000003"] [search earliest='2026-02-01 00:00:00' latest='2026-02-28 23:59:59' source=windows-network_connection-* | where Initiated="true" | eval event_type="20000301-0000-0000-0000-000000000003"] | stats dc(event_type) as unique_rules by span(@timestamp, 2m), Computer | where unique_rules >= 2"""
+    ]
 
-""")
-    ) == ['| multisearch [search earliest=\'2026-02-01 00:00:00\' latest=\'2026-02-28 23:59:59\' source=windows-process_creation-* | where LIKE(CommandLine, "%suspicious%")] [search earliest=\'2026-02-01 00:00:00\' latest=\'2026-02-28 23:59:59\' source=windows-network_connection-* | where Initiated="true"] | stats dc(EventID) as unique_rules by span(@timestamp, 2m), Computer | where unique_rules >= 2']
 
-def test_option_correlation_value_count():
-    backend = OpenSearchPPLBackend(min_time='-7d', max_time='now')
+def test_backend_option_correlation_value_count_time():
+    backend = OpenSearchPPLBackend(min_time="-7d", max_time="now")
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
 title: Detection Rule - PowerShell Execution
@@ -1806,12 +1673,12 @@ description: Detect PowerShell execution
 author: Adrian
 date: 2026/03/01
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-  condition: selection
+    selection:
+        Image|endswith: '\powershell.exe'
+    condition: selection
 level: medium
 ---
 title: Correlation - Distinct PowerShell Commands
@@ -1821,22 +1688,26 @@ description: Test value_count correlation with backend options
 author: Adrian
 date: 2026/03/01
 correlation:
-  type: value_count
-  rules:
-    - 20000200-0000-0000-0000-000000000002
-  group-by:
-    - User
-  timespan: 10m
-  condition:
-    field: CommandLine
-    gte: 3
+    type: value_count
+    rules:
+        - 20000200-0000-0000-0000-000000000002
+    group-by:
+        - User
+    timespan: 10m
+    condition:
+        field: CommandLine
+        gte: 3
 level: high
+        """)
+    ) == [
+        r"""earliest=-7d latest=now source=windows-process_creation-* | where LIKE(Image, "%\\powershell.exe", false) | stats dc(CommandLine) as value_count by span(@timestamp, 10m), User | where value_count >= 3"""
+    ]
 
-""")
-    ) == ['| search earliest=-7d latest=now source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") | stats dc(CommandLine) as value_count by User | where value_count >= 3']
 
 def test_option_correlation_with_custom_index():
-    backend = OpenSearchPPLBackend(custom_logsource='threat-intel-*', min_time='-48h', max_time='now')
+    backend = OpenSearchPPLBackend(
+        custom_logsource="threat-intel-*", min_time="-48h", max_time="now"
+    )
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
 title: Detection Rule - Malware Execution
@@ -1846,12 +1717,12 @@ description: Detect malware execution
 author: Adrian
 date: 2026/03/01
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:
-    CommandLine|contains: 'malware'
-  condition: selection
+    selection:
+        CommandLine|contains: 'malware'
+    condition: selection
 level: critical
 ---
 title: Correlation - Malware Activity Pattern
@@ -1861,153 +1732,175 @@ description: Test event_count correlation with custom index from backend option
 author: Adrian
 date: 2026/03/01
 correlation:
-  type: event_count
-  rules:
-    - 20000400-0000-0000-0000-000000000004
-  group-by:
-    - Computer
-  timespan: 15m
-  condition:
-    gte: 3
+    type: event_count
+    rules:
+        - 20000400-0000-0000-0000-000000000004
+    group-by:
+        - Computer
+    timespan: 15m
+    condition:
+        gte: 3
 level: critical
+        """)
+    ) == [
+        r"""earliest=-48h latest=now source=threat-intel-* | where LIKE(CommandLine, "%malware%", false) | stats count() as event_count by span(@timestamp, 15m), Computer | where event_count >= 3"""
+    ]
 
-""")
-    ) == ['| search earliest=-48h latest=now source=threat-intel-* | where LIKE(CommandLine, "%malware%") | stats count() as event_count by Computer | where event_count >= 3']
 
-def test_option_custom_logsource():
-    backend = OpenSearchPPLBackend(custom_logsource='my-custom-logs-*')
+def test_backend_option_custom_logsource_precedence():
+    backend = OpenSearchPPLBackend(custom_logsource="my-custom-logs-*")
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
-title: Test Custom Logsource
-id: 12345678-1234-1234-1234-123456789002
-status: test
-description: Test rule with custom logsource override
-author: Adrian
-date: 2026/02/28
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-    CommandLine|contains: 'Invoke-'
-  condition: selection
-level: medium
+            title: Test Custom Logsource
+            id: 12345678-1234-1234-1234-123456789002
+            status: test
+            description: Test rule with custom logsource override
+            author: Adrian
+            date: 2026/02/28
+            logsource:
+                product: windows
+                category: process_creation
+            detection:
+                selection:
+                    Image|endswith: '\powershell.exe'
+                    CommandLine|contains: 'Invoke-'
+                condition: selection
+            level: medium
+            opensearch_ppl_backend:
+                index: correct-custom-logs-*
+        """)
+    ) == [
+        r"""source=correct-custom-logs-* | where LIKE(Image, "%\\powershell.exe", false) AND LIKE(CommandLine, "%Invoke-%", false)"""
+    ]
 
-""")
-    ) == ['source=my-custom-logs-* | where LIKE(Image, "%powershell.exe") AND LIKE(CommandLine, "%Invoke-%")']
 
-def test_option_default_logsource():
-    backend = OpenSearchPPLBackend()
+def test_backend_option_correlation_custom_logsource_precedence():
+    backend = OpenSearchPPLBackend(custom_logsource="my-custom-logs-*")
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
-title: Test Default Logsource
-id: 12345678-1234-1234-1234-123456789001
+title: Detection Rule 1 - Suspicious Process
+id: 20000300-0000-0000-0000-000000000003
 status: test
-description: Test rule for default logsource generation
+description: Detect suspicious process execution
 author: Adrian
-date: 2026/02/28
+date: 2026/03/01
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-    CommandLine|contains: 'Invoke-'
-  condition: selection
+    selection:
+        CommandLine|contains: 'suspicious'
+    condition: selection
 level: medium
+opensearch_ppl_backend:
+    index: correct-custom-logs1-*
+---
+title: Detection Rule 2 - Network Connection
+id: 20000301-0000-0000-0000-000000000003
+status: test
+description: Detect network connection initiated
+author: Adrian
+date: 2026/03/01
+logsource:
+    product: windows
+    category: network_connection
+detection:
+    selection:
+        Initiated: 'true'
+    condition: selection
+level: low
+---
+title: Correlation - Temporal Correlation
+id: 20000302-0000-0000-0000-000000000003
+status: test
+description: Test temporal correlation with backend options
+author: Adrian
+date: 2026/03/01
+correlation:
+    type: temporal
+    rules:
+        - 20000300-0000-0000-0000-000000000003
+        - 20000301-0000-0000-0000-000000000003
+    group-by:
+        - Computer
+    timespan: 2m
+level: high
+        """)
+    ) == [
+        r"""| multisearch [search source=correct-custom-logs1-* | where LIKE(CommandLine, "%suspicious%", false) | eval event_type="20000300-0000-0000-0000-000000000003"] [search source=my-custom-logs-* | where Initiated="true" | eval event_type="20000301-0000-0000-0000-000000000003"] | stats dc(event_type) as unique_rules by span(@timestamp, 2m), Computer | where unique_rules >= 2"""
+    ]
 
-""")
-    ) == ['source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") AND LIKE(CommandLine, "%Invoke-%")']
 
-def test_option_time_filters_absolute():
-    backend = OpenSearchPPLBackend(min_time='2024-01-01T00:00:00', max_time='2024-01-31T23:59:59')
+def test_backend_option_time_max_only():
+    backend = OpenSearchPPLBackend(max_time="now")
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
-title: Test Absolute Time Filters
-id: 12345678-1234-1234-1234-123456789004
-status: test
-description: Test rule with absolute time filters
-author: Adrian
-date: 2026/02/28
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-    CommandLine|contains: 'Invoke-'
-  condition: selection
-level: medium
+            title: Test Max Time Filter Only
+            id: 12345678-1234-1234-1234-123456789006
+            status: test
+            description: Test rule with only maximum time filter
+            author: Adrian
+            date: 2026/02/28
+            logsource:
+                product: windows
+                category: process_creation
+            detection:
+                selection:
+                    Image|endswith: '\powershell.exe'
+                    CommandLine|contains: 'Invoke-'
+                condition: selection
+            level: medium
+        """)
+    ) == [
+        r"""latest=now source=windows-process_creation-* | where LIKE(Image, "%\\powershell.exe", false) AND LIKE(CommandLine, "%Invoke-%", false)"""
+    ]
 
-""")
-    ) == ['search earliest=\'2024-01-01 00:00:00\' latest=\'2024-01-31 23:59:59\' source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") AND LIKE(CommandLine, "%Invoke-%")']
 
-def test_option_time_filters_max_only():
-    backend = OpenSearchPPLBackend(max_time='now')
+def test_backend_option_time_min_only():
+    backend = OpenSearchPPLBackend(min_time="-7d")
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
-title: Test Max Time Filter Only
-id: 12345678-1234-1234-1234-123456789006
-status: test
-description: Test rule with only maximum time filter
-author: Adrian
-date: 2026/02/28
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-    CommandLine|contains: 'Invoke-'
-  condition: selection
-level: medium
+            title: Test Min Time Filter Only
+            id: 12345678-1234-1234-1234-123456789005
+            status: test
+            description: Test rule with only minimum time filter
+            author: Adrian
+            date: 2026/02/28
+            logsource:
+                product: windows
+                category: process_creation
+            detection:
+                selection:
+                    Image|endswith: '\powershell.exe'
+                    CommandLine|contains: 'Invoke-'
+                condition: selection
+            level: medium
+        """)
+    ) == [
+        r"""earliest=-7d source=windows-process_creation-* | where LIKE(Image, "%\\powershell.exe", false) AND LIKE(CommandLine, "%Invoke-%", false)"""
+    ]
 
-""")
-    ) == ['search latest=now source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") AND LIKE(CommandLine, "%Invoke-%")']
 
-def test_option_time_filters_min_only():
-    backend = OpenSearchPPLBackend(min_time='-7d')
+def test_backend_option_time_rounding():
+    backend = OpenSearchPPLBackend(min_time="-1d@d", max_time="-30m@m")
     assert backend.convert(
         SigmaCollection.from_yaml(r"""
-title: Test Min Time Filter Only
-id: 12345678-1234-1234-1234-123456789005
-status: test
-description: Test rule with only minimum time filter
-author: Adrian
-date: 2026/02/28
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-    CommandLine|contains: 'Invoke-'
-  condition: selection
-level: medium
-
-""")
-    ) == ['search earliest=-7d source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") AND LIKE(CommandLine, "%Invoke-%")']
-
-def test_option_time_filters_relative():
-    backend = OpenSearchPPLBackend(min_time='-30d', max_time='now')
-    assert backend.convert(
-        SigmaCollection.from_yaml(r"""
-title: Test Relative Time Filters
-id: 12345678-1234-1234-1234-123456789003
-status: test
-description: Test rule with relative time filters (-30d to now)
-author: Adrian
-date: 2026/02/28
-logsource:
-  product: windows
-  category: process_creation
-detection:
-  selection:
-    Image|endswith: '\powershell.exe'
-    CommandLine|contains: 'Invoke-'
-  condition: selection
-level: medium
-
-""")
-    ) == ['search earliest=-30d latest=now source=windows-process_creation-* | where LIKE(Image, "%powershell.exe") AND LIKE(CommandLine, "%Invoke-%")']
+            title: Test Relative Time Filters
+            id: 12345678-1234-1234-1234-123456789003
+            status: test
+            description: Test rule with rounding time filters
+            author: Adrian
+            date: 2026/02/28
+            logsource:
+                product: windows
+                category: process_creation
+            detection:
+                selection:
+                    Image|endswith: '\powershell.exe'
+                    CommandLine|contains: 'Invoke-'
+                condition: selection
+            level: medium
+        """)
+    ) == [
+        r"""earliest='-1d@d' latest='-30m@m' source=windows-process_creation-* | where LIKE(Image, "%\\powershell.exe", false) AND LIKE(CommandLine, "%Invoke-%", false)"""
+    ]


### PR DESCRIPTION
I took over the PPL backend from Adrian (who did the initial implementation). We recently started using it in an internal solution and found some things that initially escaped us, so I came up with some fixes. The diff is pretty big, but that is mostly due to style changes and removals.

With the permission of the current maintainers I can also add myself to the README as the maintainer for the PPL part of the backend.

### Bug fixes
- Boolean values where not implemented.
- Regex handling reimplemented using deferred expressions. OR-ed regex expressions not implemented. At best it's not trivial, at worst it's impossible. Will look into this for the future, but for now it was not worth the effort. 
The previous implementation was using the `match` PPL function which does full-text search, not regex matching.
- Unbound values reimplemented using the `query_string` function which does a full-text search over all the default fields in an index. Previously, rules with unbound values would emit invalid queries like `source=index | where "value1", "value2"`.
- Reimplemented temporal aggregations. Due to a misunderstanding, they were counting an inexisting field before.
- Implemented field aliasing.
- Fixed the tests for all of the above.

### Style fixes
- Used `ruff` with default settings on both backend file and tests.
- Shifted some class variables around to better align with the order in the `TextQueryBackend` base class.
- Added some type hints to please the type checker. Added comments for pyright to ignore some stuff where not possible.
- Simplified implementation where possible, relying more on the `TextQueryBackend` default behaviour. 

### Removals and breaking changes
While I don't think many people were using this backend, I am sorry for the breaking changes. Some of the removed things came from requirements that sounded good in theory, but we did not really use in the end, so we couldn't justify the complexity of the backend for those.

- [Breaking change] Removed temporal ordered aggregations. Previously they were implemented the same as the temporal ones, which is not that helpful.
- [Breaking change] Removed the ability to specify time ranges (used in the `earliest` and `latest` PPL time modifiers) inside a rule via custom attributes. The reasoning behind this is that it is not that useful and it was getting messy with correlation rules. Initially, time ranges set on a rule used in a correlation were prioritised, but it doesn't really make sense to have different time ranges for the sub-searches in a temporal correlation. Overall the gain for this was pretty much non-existent. Time range options can still be set on backend instantiation, through the `min_time` and `max_time` options.
- [Breaking change] Removed the ability to specify a custom time field for aggregations. All agregations use the default OpenSearch time field now (`@timestamp`)
- [Breaking change] Renamed the custom attribute key to `opensearch_ppl_backend` (from `custom`) for better clarity. This way of specifying custom options (well, option really: the custom index) is not really recommended; processing pipelines are better for mapping logsources to indices and probably for most usecases.
- Removed tests for the above.
